### PR TITLE
Add feature to add transclusion for standard org link types: heading Demo #3

### DIFF
--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -172,7 +172,6 @@ PATH is assumed to be of the form: file:path/to/file.org::dedicted-link."
         (org-with-wide-buffer
          (org-link-search paragraph-id)
          (mark-paragraph)
-         (forward-char) ;; move to the same line where the content begins
          (let* ((beg (point-marker)) ;; it is the beginning of the paragraph
                 (end (mark-marker))
                 (content (buffer-substring beg end)))

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -175,6 +175,7 @@ PATH is assumed to be of the form: file:path/to/file.org::dedicted-link."
          (let* ((beg (point-marker)) ;; it is the beginning of the paragraph
                 (end (mark-marker))
                 (content (buffer-substring beg end)))
+           (deactivate-mark)
            (list :tc-content content
                  :tc-beg-mkr beg
                  :tc-end-mkr end)))))))

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -5,7 +5,7 @@
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; URL: https://github.com/nobiot/org-transclusion
 ;; Keywords: org-mode, transclusion, writing
-;; Version: 0.0.2
+;; Version: 0.0.3
 ;; Package-Requires: ((emacs "26.3") (org "9.3")
 
 ;; This program is free software: you can redistribute it and/or modify

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -510,8 +510,10 @@ to avoid recursion."
         ;; link.  This is because fn returns a message string when there is no
         ;; further link.
         (while (eq t (org-next-link))
-          ;; check if the link at point is tranclusion link
-          (when (org-transclusion--transclusion-link-p)
+          ;; Check if the link at point is tranclusion link
+          ;; Check if the link is in the beginning of a line
+          (when (and (eq (line-beginning-position) (point))
+                     (org-transclusion--transclusion-link-p))
             (let* ((link (org-element-link-parser))
                    (path (org-element-property :path link)))
               (org-transclusion-call-add-at-point-functions path))))))))


### PR DESCRIPTION
This is features added and showed with demo#3.

1. `otc:` link type supports `file.org::*headline` and `file.org::paragraph`
Variable `org-transclusion-add-at-point-functions` to control transclusion behaviour
2. Translude Org Mode standard `[[file:path/to/file.org::*headline][support headline]]`
Variable `org-transclusion-add-org-link-at-point-function` to control transclusion behaviour
3. New issue: A buffer can transclude overlapping regions