### PR TITLE
Add feature to include first section for Org file

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ It is a list of symbols, and the default is `(property-drawer)`. The accepted va
 
 How to use it is demonstrated in the [YouTube video #5](https://youtu.be/hz92vaO8IgQ) as well.
 
+### Customisable filter to exclude certain Org elements
+After the v0.0.5, a feature to include the first section (section before the first headline) is added. It is toggled via cusotmizing variable `org-transclusion-include-first-section`. Its default value is `nil`. Set it to `t` to transclude the first section.
+
 ### Link to a paragraph with dedicated target
 For transcluding a specific paragraph, Org-transclusion relies on Org mode's [dedicated-target](https://orgmode.org/manual/Internal-Links.html#Internal-Links). The target paragraph must be identifiable by a dedicated target with a `<<paragraph-id>>`: e.g.
 

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -96,6 +96,13 @@ Refer to variable `org-element-all-elements' for names of elements accepted."
   :type '(repeat symbol)
   :group 'org-transclusion)
 
+(defcustom org-transclusion-include-first-section nil
+  "Define whether or not transclusion for Org files includes \"first section\".
+If t, the section before the first headline is
+transcluded. Default is nil."
+  :type 'boolean
+  :group 'org-transclusion)
+
 (defcustom org-transclusion-link "otc"
   "Define custom Org link type name used for transclusion links."
   :type 'string
@@ -246,7 +253,7 @@ is used (ARG is non-nil), then use `org-link-open'."
          ;; Intended to remove the first section, taht is the part before the first headlne
          ;; the rest of the sections are included in the headlines
          ;; Thies means that if there is no headline, nothing gets transcluded.
-         nil)
+         (if org-transclusion-include-first-section data nil))
         (t
          ;; Rest of the case.
          (org-element-map data org-transclusion-exclude-elements (lambda (d)


### PR DESCRIPTION
After the v0.0.5, a feature to include the first section (section before the first headline) is added. It is toggled via cusotmizing variable `org-transclusion-include-first-section`. Its default value is `nil`. Set it to `t` to transclude the first section.

Motivation: #25 
But it does not fix the root cause of the error -- when `tc-content` is `""` it will still emits an error and does bag things...