### PR TITLE
Emphasize that no space before link is allowed

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To transclude text content via a link, use Org's normal file link immediately fo
 
 Use a value `t` or `nil` for the `#+transclude:` keyword to control whether or not Org-transclusion is to transclude the content via the link in question.
 
-The link must be in the beginning of a line for transclusion. If there is any character (even a space for indentation), Org-transclusion skips it. This is to avoid transcluding links in the middle of a sentence.
+**The link must be in the beginning of a line for transclusion.** If there is any character (even a space for indentation), Org-transclusion skips it. This is to avoid transcluding links in the middle of a sentence.
 
 Org-transclusion also skips transclusion links within another transclusion in order to avoid multiple recursions.
 


### PR DESCRIPTION
First great thanks for creating this package!
I have been impressed with what `org-transclusion` can achieve, by the demonstration videos and the presentation in EmacsConf2020. I watched all the YouTube videos, and decided to give it a try. Unfortunately, I tried it several times in the past few weeks, and it just refused to work. Today, I decided to look into the code to see what's wrong. In a couple of minutes, I noticed a test of `(bolp)`. So transclusion links will only work if there is no space before it. Sure enough, this is documented in README and is for good reason. I am only making the text bold so no other people will let it go unnoticed, like I did.