### PR TITLE
Support more search options in file links

### DIFF
--- a/README.org
+++ b/README.org
@@ -248,12 +248,16 @@ In the live-sync edit region, the normal =yank= command (=C-y=) is replaced with
 Transclusion has been tested to work for the following types of links:
 
 - File link for an entire org file/buffer; e.g. =[[file:~/org/file.org][My Org Notes]]=
+- File link with =::line-number=; The default behavior is transcluding the paragraph around the line-number.
 - File link with =::*heading=
 - File link with =::#custom-id=
+- File link with =::/regexp/=; The default behavior is transcluding the last occurance of matched text.
 - File link with =::name= for blocks (e.g. blocked quotations), tables, and links
 - File link with =::dedicated-target=; this is intended for linking to a paragraph. See below.
 - ID link =id:uuid=
-- File link for non-org files (tested with =.txt= and =.md=); for these, the whole buffer gets transcluded
+- File link for non-org files (tested with =.txt= and =.md=); is also supported but,
+  org-specific options will be treated as an regexp e.g. =::*heading=, =::#custom-id=,
+  =::dedicated-target= and =::name= etc.
 
 For transcluding a specific paragraph, Org-transclusion relies on Org mode's [[https://orgmode.org/manual/Internal-Links.html#Internal-Links][dedicated-target]]. The target paragraph must be identifiable by a dedicated target with a =<<paragraph-id>>=: 
 

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -592,10 +592,11 @@ type.
 
 Assume this function is called with the point on an
 org-transclusion overlay."
-  (let ((type (get-text-property (point) 'tc-type)))
+  (let ((type (get-text-property (point) 'tc-type))
+	(parent (get-text-property (point) :parent)))
     (cond
      ;; Org Link and ID
-     ((string-prefix-p "org" type 'ignore-case)
+     ((and (string-prefix-p "org" type 'ignore-case) parent)
       (org-transclusion-live-sync-buffers-get-org))
      (t (org-transclusion-live-sync-buffers-get-others-default)))))
 
@@ -1179,18 +1180,18 @@ to include the first section."
 Returns non-nil if check is pass."
   t)
 
-(defun org-transclusion--add-others-default (path)
-  "Use PATH to return TC-CONTENT, TC-BEG-MKR, and TC-END-MKR.
-TODO need to handle when the file does not exist."
-  (let ((buf (find-file-noselect path)))
-    (with-current-buffer buf
-      (org-with-wide-buffer
-       (let ((content (buffer-string))
-             (beg (point-min-marker))
-             (end (point-max-marker)))
-         (list :tc-content content
-               :tc-beg-mkr beg
-               :tc-end-mkr end))))))
+;; (defun org-transclusion--add-others-default (path)
+;;   "Use PATH to return TC-CONTENT, TC-BEG-MKR, and TC-END-MKR.
+;; TODO need to handle when the file does not exist."
+;;   (let ((buf (find-file-noselect path)))
+;;     (with-current-buffer buf
+;;       (org-with-wide-buffer
+;;        (let ((content (buffer-string))
+;;              (beg (point-min-marker))
+;;              (end (point-max-marker)))
+;;          (list :tc-content content
+;;                :tc-beg-mkr beg
+;;                :tc-end-mkr end))))))
 
 ;;-----------------------------------------------------------------------------
 ;;; Utility Functions

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -401,7 +401,7 @@ You can customize the keymap with using `org-transclusion-map':
                (let* ((tc-type (plist-get tc-params :tc-type))
                       (tc-arg (plist-get tc-params :tc-arg))
                       (tc-fn (plist-get tc-params :tc-fn))
-                      (tc-payload (funcall tc-fn tc-arg tc-type))
+                      (tc-payload (funcall tc-fn tc-arg))
                       (tc-beg-mkr (plist-get tc-payload :tc-beg-mkr))
                       (tc-end-mkr (plist-get tc-payload :tc-end-mkr))
                       (tc-content (plist-get tc-payload :tc-content)))
@@ -927,19 +927,6 @@ Return nil if not found."
 	    :tc-arg link
 	    :tc-fn #'org-transclusion-content-get-from-file-link))))
 
-;; (defun org-transclusion-link-open-org-file-links (link)
-;;   "Return a list for Org file LINK object.
-;; Return nil if not found."
-;;   (when (org-transclusion--org-file-p (org-element-property :path link))
-;;     (list :tc-type "org-link"
-;;           :tc-arg link
-;;           :tc-fn #'org-transclusion-content-get-from-org-link)))
-
-;; (defun org-transclusion-link-open-other-file-links (link)
-;;   "Return a list for non-Org file LINK object.
-;; Return nil if not found."
-;;   (org-transclusion--get-custom-tc-params link))
-
 (defun org-transclusion-content-get-from-org-marker (marker)
   "Return tc-beg-mkr, tc-end-mkr, tc-content from MARKER.
 This is meant for Org-ID."
@@ -955,30 +942,12 @@ This is meant for Org-ID."
              (org-transclusion-content-get-org-buffer-or-element-at-point 'only-element)))))
     (message "Nothing done. Cannot find marker for the ID.")))
 
-;; (defun org-transclusion-content-get-from-org-link (link &rest _arg)
-;;   "Return tc-beg-mkr, tc-end-mkr, tc-content from LINK."
-;;   (save-excursion
-;;     ;; First visit the buffer and go to the relevant elelement if id or
-;;     ;; search-option is present.
-;;     (let* ((path (org-element-property :path link))
-;;            (search-option (org-element-property :search-option link))
-;;            (buf (find-file-noselect path)))
-;;       (with-current-buffer buf
-;;         (org-with-wide-buffer
-;;          ;;(outline-show-all)
-;;          (if search-option
-;;              (progn
-;;                (org-link-search search-option)
-;;                (org-transclusion-content-get-org-buffer-or-element-at-point 'only-element))
-;;            (org-transclusion-content-get-org-buffer-or-element-at-point)))))))
-
-(defun org-transclusion-content-get-from-file-link (link &optional type)
+(defun org-transclusion-content-get-from-file-link (link)
   "Return tc-beg-mkr, tc-end-mkr, tc-content from file LINK."
   (save-excursion
     ;; First visit the buffer and go to the relevant elelement if id or
     ;; search-option is present.
     (let* ((path (org-element-property :path link))
-	   (file-type (or type (org-element-property :type link)))
            (search-option (org-element-property :search-option link)))
       (if (file-exists-p path) ;; Check if file exists,
 	  (with-current-buffer (find-file-noselect path) ;; if yes, open file in another buffer
@@ -986,7 +955,7 @@ This is meant for Org-ID."
 	     (apply #'org-transclusion-content-get-buffer-or-element
 		      link
 		      ;; Start constructing arguments 
-		      (string-match-p "org-link" file-type) ;; Check if this is an org file.
+		      (org-transclusion--org-file-p path) ;; Check if this is an org file.
 		      search-option ;; Having search option implies non-nil only-element argument.
 		      (cond ((not search-option) nil) ;; No search options, invoke right away, yields whole buffer.
 			    ((string-match-p "\\`[0-9]+\\'" search-option) ;; Check if option is for line,

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -1096,9 +1096,11 @@ A non-nil SEARCH-OPTION return only the element, that the search matches."
 		   (match-data))))))))
       (cond
        ;; If this is an org file and no search option, get the whole buffer.
-       ((and org-p (not only-element)) (org-transclusion-content-get-org-buffer-or-element-at-point nil))
-       ;; If this is an org file and search option is org-specific, get only that element
-       ((and org-p (string-match-p "^*.*\\|^#.*" search-option)) (org-transclusion-content-get-org-buffer-or-element-at-point t))
+       ((and org-p (not only-element))
+	(org-transclusion-content-get-org-buffer-or-element-at-point nil))
+       ;; If this is an org file, no line-num and search option is org-specific, get only that element
+       ((and org-p (not line-num) (string-match-p "^*.*\\|^#.*" search-option))
+	(org-transclusion-content-get-org-buffer-or-element-at-point t))
        (t
 	;; If this is non-org file or an org file with other kind of search option.
 	(progn (let* ((tc-content)(tc-beg-mkr)(tc-end-mkr)) ;; Assign empty variables

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -1003,12 +1003,16 @@ This is meant for Org-ID."
     (re-search-backward regexp nil t)))
 
 (defun org-transclusion-one-line (&optional line-num)
+  "Returns (BEG END) with the position of the first and last character of LINE-NUM,
+or the current line if LINE-NUM is nil, as BEG and END respectively."
   (save-excursion
     (when line-num
       (goto-line line-num))
     (list (line-beginning-position) (line-end-position))))
 
 (defun org-transclusion-paragraph-from-line (&optional line-num)
+  "Returns (BEG END) with the position of the beginning and end of a paragraph at LINE-NUM,
+or the current line if LINE-NUM is nil, as BEG and END respectively."
   (save-excursion
     (when line-num
       (goto-line line-num))
@@ -1087,20 +1091,20 @@ A non-nil SEARCH-OPTION return only the element, that the search matches."
 	    ;; if search-option is non-nil, return the match data.
 	    (search-option
 	     (cond
-      	      ;; When search-option is org-specific (begins "*" and "#" ) and this buffer is displaying an org file, call `org-link-search'.
-	      ((and org-p (string-match-p "^*.*\\|^#.*" search-option)) (org-link-search search-option))
+      	      ;; When this is an org file with no line search or regexp search call `org-link-search' with search option
+	      ((and org-p (not line-num) (not (string-match "/\\(.*\\)/" search-option))) (org-link-search search-string))
 	      ;; When search-option doesn't match, show error.
 	      ((zerop (how-many search-string)) (user-error "Nothing matched %s in %s" search-option (buffer-file-name)))
 	      ;; Or else, handle regexp with `org-transclusion-regexp-search-function'
 	      (t (save-match-data
-		   (funcall org-transclusion-regexp-search-function search-string)
+		   (funcall org-transclusion-regexp-search-function (concat search-string ".*"))
 		   (match-data))))))))
       (cond
        ;; If this is an org file and no search option, get the whole buffer.
        ((and org-p (not only-element))
 	(org-transclusion-content-get-org-buffer-or-element-at-point nil))
        ;; If this is an org file, no line-num and search option is org-specific, get only that element
-       ((and org-p (not line-num) (string-match-p "^*.*\\|^#.*" search-option))
+       ((and org-p (not line-num) (not (string-match "/\\(.*\\)/" search-option)))
 	(org-transclusion-content-get-org-buffer-or-element-at-point t))
        (t
 	;; If this is non-org file or an org file with other kind of search option.

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -822,6 +822,14 @@ It assumes that point is at a keyword."
 
 ;;;;-----------------------------------------------------------------------------
 ;;;; Functions for inserting content
+
+(define-obsolete-function-alias 'org-transclusion-link-open-org-file-links
+  'org-transclusion-open-file-link "Made obsolete since 0.1.2")
+(define-obsolete-function-alias 'org-transclusion-link-open-other-file-links
+  'org-transclusion-open-file-link "Made obsolete since 0.1.2")
+(define-obsolete-function-alias 'org-transclusion-content-get-from-org-link
+  'org-transclusion-content-get-from-file-link "Made obsolete since 0.1.2")
+
 (defun org-transclusion-content-insert (keyword-values type content src-beg-m src-end-m)
   "Add content and overlay.
 - KEYWORD-VALUES :: TBD


### PR DESCRIPTION
First of all, please see [ (org) Search Options ](https://orgmode.org/manual/Search-Options.html)info node for more details.
I've added support for a file link with 
**`::LINE_NUMBER`**
**`::SEARCH_STRING`**
**`::*ORG_HEADLINE`**
**`::#ORG_CUSTOM_ID`**
**`::/SEARCH_REGEXP/`**
as its ending and org-specific options like headline or custom id will be handle
as a regexp for non-org file.

Right now, live-sync works for all options I've added but,
there is some concern I have regarding using live-sync to edit a source for a regexp transclusion since it may change the match data.
