### PR TITLE
handle encrypted org files

### DIFF
--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -1219,9 +1219,17 @@ the line, add a new empty line."
 
 (defun org-transclusion-org-file-p (path)
   "Return non-nil if PATH is an Org file.
-Checked with the extension `org'."
-  (let ((ext (file-name-extension path)))
-    (string= ext "org")))
+It does so by confirming that the extension is either `org' or `org.gpg'.
+The latter form of extension ending with .gpg means it is an encrypted org file.
+file-name-extension is used to ascertain that PATH is valid."
+  (when (file-name-extension path)
+    (let* ((path-substrings (split-string path "\\."))
+           (last-two-substings (last path-substrings 2))
+           (last-substring (car (last last-two-substings)))
+           (org-file (string= last-substring "org"))
+           (encrpyted-org-file (and (string= (car last-two-substings) "org")
+                                    (string= last-substring "gpg"))))
+      (or org-file encrpyted-org-file))))
 
 (defun org-transclusion-not-nil (v)
   "Return t or nil.

--- a/test/unit-tests.el
+++ b/test/unit-tests.el
@@ -1,0 +1,17 @@
+;;; unit-tests.el --- Description -*- lexical-binding: t; -*-
+;; org-transclusion unit tests
+;; To run the tests you can use: M-x ert RET t RET
+;; You can read more about ert here: https://www.gnu.org/software/emacs/manual/html_node/ert/index.html
+
+(ert-deftest org-transclusion-org-file-p-test ()
+  "Tests org-transclusion-org-file-p against string inputs."
+  (should (equal (org-transclusion-org-file-p "test.org.gpg") t))
+  (should (equal (org-transclusion-org-file-p "test.org") t))
+  (should (equal (org-transclusion-org-file-p "test.gpg") nil))
+  (should (equal (org-transclusion-org-file-p "no-extention") nil))
+  (should (equal (org-transclusion-org-file-p ".org") nil))
+  (should (equal (org-transclusion-org-file-p ".gpg") nil))
+  (should (equal (org-transclusion-org-file-p ".") nil))
+  (should (equal (org-transclusion-org-file-p "") nil)))
+
+;;; unit-tests.el ends here


### PR DESCRIPTION
Hi @nobiot!

First of all thanks a lot for this amazing package.

I've started using it today and just noticed that when an org file is encrypted (i.e. [filename].org.gpg) it behaves unexpectedly. From what I observed, when trying to transclude a heading from an encrypted org file, the entire contents of the file get included instead of the linked heading. Note that I'm using org-roam with encryption so if there are people like me out there with the same set up they might run into the same problem.

After looking into it, I noticed that a file link from an encrypted org file is treated as others-default because `org-transclusion-org-file-p` ([this one](https://github.com/nobiot/org-transclusion/blob/7b141a96d7793124e0afa1a2c0856ee57e9967aa/org-transclusion.el#L1219)) returns nil, because it does not recognise an org file that also has .gpg at the end, so `org-transclusion-add-other-file` ends up getting invoked and the `tc-type` becomes `others-default`. 

I've got my take on how to solve this in this request alongside a simple unit test. 

Please let me know if any of this doesn't make sense and need me to clarify!
Cheers!