### PR TITLE
Correct command names in README to match v0.2.0

### DIFF
--- a/README.org
+++ b/README.org
@@ -138,7 +138,7 @@ Put your cursor somewhere on this link and call  =M-x org-transclusion-make-from
 #+transclude: [[id:20210501T171427.051019][Bertrand Russell]]
 #+end_example
 
-Put your cursor somewhere on this keyword line and call =M-x org-transclusion-add-at-point=, and you will see the content the ID points to be copied over, replacing the =transclude= keyword.
+Put your cursor somewhere on this keyword line and call =M-x org-transclusion-add=, and you will see the content the ID points to be copied over, replacing the =transclude= keyword.
 
 [[./resources/2021-05-09T190918.png]]
 
@@ -325,7 +325,7 @@ If you have other windows open, they will be temporarily hidden -- Org-transclus
 
 In the live-sync edit region, you can freely type to edit the tranclusion or source regions; they will sync simultaneously.
 
-Once done with editing, press =C-c C-c= to exit live-sync edit. The key is bound to =org-transclusion-live-sync-exit-at-point=. It will turn off the live sync edit but keep the transclusion on. 
+Once done with editing, press =C-c C-c= to exit live-sync edit. The key is bound to =org-transclusion-live-sync-exit=. It will turn off the live sync edit but keep the transclusion on.
 
 In the live-sync edit region, the normal =yank= command (=C-y=) is replaced with a special command =org-transclusion-live-sync-paste=. This command lets the pasted text inherit the text-properties of the transcluded region correctly; the normal yank does not have this feature and thus causes some inconvenience in live-sync edit. If you use vim keybindings (e.g. =evil-mode=), it is advised that you review the default keybindings. You can customize the local keybindings for the live-sync region by =org-transclusion-live-sync-map=. 
 
@@ -341,10 +341,10 @@ In the live-sync edit region, the normal =yank= command (=C-y=) is replaced with
  key                   binding
  ---                   -------
  
- C-c			Prefix Command
- C-y			org-transclusion-live-sync-paste
+ C-c                   Prefix Command
+ C-y                   org-transclusion-live-sync-paste
  
- C-c C-c		org-transclusion-live-sync-exit-at-point
+ C-c C-c               org-transclusion-live-sync-exit
 
  *Also inherits ‘org-mode-map’
 #+end_example


### PR DESCRIPTION
Hi @nobiot 

It's me again :) 
I just noticed, in the README, that some command names appears to be out of date.
It looks like you've fixed most of them after the v0.2.0 version bump so I could only find a few of them.
I've also fixed some alignment in case you were wondering what was happening in the last hunk around line 344.

Anyways I hope it helps! 

Thanks
