### PR TITLE
Fixes part of issue #91 regarding nested headings

### DIFF
--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -517,7 +517,7 @@ When success, return the beginning point of the keyword re-inserted."
         ;; if any.  If their positions differ after insert, move them back
         ;; beg or end
         (let* ((prev-end (get-text-property (1- beg) 'org-transclusion-end-mkr))
-               (is-nested (and prev-end (< prev-end beg)))
+               (is-nested (and prev-end (> prev-end beg)))
                (mkr-at-beg
                ;; Check the points to look at exist in buffer.  Then look for
                ;; adjacent transclusions' markers if any.


### PR DESCRIPTION
Fixed the combination of some breaking assumptions of
`org-transclusion-remove` in the presence of nested transclusioins:

- the character right before the beginning of a transclusion is not
  necessarily an adjacent transclusion. It might be the parent
  transclusion.

- Using `insert-before-markers` to re-insert the `#+transclude: ...`
  element loses information about the text properties present before
  inserting the cloned text. This is still prone to bugs but using
  `insert-before-markers-and-inherit` instead avoids the common case
  errors.