### PR TITLE
fix:#115 Allow adding #+name, etc. before #+transclude keyword

### DIFF
--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -17,7 +17,7 @@
 
 ;; Author:        Noboru Ota <me@nobiot.com>
 ;; Created:       10 October 2020
-;; Last modified: 30 December 2021
+;; Last modified: 04 January 2022
 
 ;; URL: https://github.com/nobiot/org-transclusion
 ;; Keywords: org-mode, transclusion, writing
@@ -831,7 +831,9 @@ It needs to be set in
 Returns t if successful.  It checks if the element at point is a
 keyword.  If not, returns nil."
   (let* ((elm (org-element-at-point))
-         (beg (org-element-property :begin elm))
+         ;; Ignore and keep affiliated keywords before #+transclusion
+         ;; Fix issue #115
+         (beg (org-element-property :post-affiliated elm))
          (end (org-element-property :end elm))
          (post-blank (org-element-property :post-blank elm)))
     (when (string= "keyword" (org-element-type elm))

--- a/test/test-2.1-lines.org
+++ b/test/test-2.1-lines.org
@@ -6,6 +6,7 @@ Including lines of source code
 
 [[file:./paragraph.org::/Lorem/]]
 
+#+name: source code 1
 #+transclude: [[file:../org-transclusion-src-lines.el]] :lines 1-10 :src elisp
 #+transclude: [[file:test-src.el]] :lines 1-
 #+transclude: [[file:test-src.el]] :lines 2-4 :src elisp


### PR DESCRIPTION
The keyword (including #+transclude) element includes the affiliated
keywords (the keywords before #+transclude) such as #+name, #+caption. Thus,
removing the whole element from beg to end also removes them all. Changing the
region's beginning to post-affiliated includes only the #+transclude keyword,
keeping the affiliated keywords as they are.