### PR TITLE
Use org-mode keymap as a parent to reuse binding

### DIFF
--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -218,6 +218,7 @@ regexp from the string.")
 
 (defvar org-transclusion-map
   (let ((map (make-sparse-keymap)))
+    (set-keymap-parent map org-mode-map)
     (define-key map (kbd "e") #'org-transclusion-live-sync-start)
     (define-key map (kbd "g") #'org-transclusion-refresh)
     (define-key map (kbd "d") #'org-transclusion-remove)
@@ -225,8 +226,6 @@ regexp from the string.")
     (define-key map (kbd "D") #'org-transclusion-demote-subtree)
     (define-key map (kbd "o") #'org-transclusion-open-source)
     (define-key map (kbd "O") #'org-transclusion-move-to-source)
-    (define-key map (kbd "TAB") #'org-cycle)
-    (define-key map (kbd "C-c C-c") #'org-ctrl-c-ctrl-c)
     map)
   "It is the local-map used within a transclusion.
 As the transcluded text content is read-only, these keybindings


### PR DESCRIPTION
This makes available the whole keybindings of Org mode even whern org-transclusion-mode is running.
The keybindings of org-transclusion override Org mode map (that's how keybinding inheritance works)

I followed the guide at
https://www.gnu.org/software/emacs/manual/html_node/elisp/Inheritance-and-Keymaps.html

because I really cannot enjoy an Org file without most of Org key
bindings available :)

Happy to close it if that is not what you want for your mode.