### PR TITLE
Feat/after add hook

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -8,4 +8,7 @@
   ;; time stamp with English
   (system-time-locale . "C"))
   (fill-column . 80)
-  (indent-tabs-mode . nil))
+  (indent-tabs-mode . nil)
+  (coding . utf-8)
+  (require-final-newline: t)
+  (sentence-end-double-space: t))

--- a/docs/org-transclusion-manual.org
+++ b/docs/org-transclusion-manual.org
@@ -1,7 +1,7 @@
 #+title: Org-transclusion User Manual
 #+author: Noboru Ota <me@nobiot.com>
 #+macro: version 1.1.x
-#+macro: modified 29 December 2021
+#+macro: modified 07 January 2022
 
 #+language: en
 #+export_file_name: org-transclusion.texi
@@ -116,7 +116,8 @@ e               org-transclusion-live-sync-start
 g               org-transclusion-refresh
 o               org-transclusion-open-source
 
-C-c C-c         org-ctrl-c-ctrl-c
+    †‧Also inherits ‘org-mode-map’ as of development version 1.1.1.0.20220106.203639
+      and planned to be part of 1.2.0
 
 #+end_example
 
@@ -324,7 +325,7 @@ In the live-sync edit region, the normal =yank= command (=C-y=) is replaced with
 
  C-c C-c               org-transclusion-live-sync-exit
 
- *Also inherits ‘org-mode-map’
+    †‧Also inherits ‘org-mode-map’
 #+end_example
 
 ** Transclude source file into src-block

--- a/org-transclusion-indent-mode.el
+++ b/org-transclusion-indent-mode.el
@@ -17,7 +17,7 @@
 
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; Created: 22 August 2021
-;; Last modified: 4 December 2021
+;; Last modified: 07 January 2022
 
 ;;; Commentary:
 ;;  This file is part of Org-transclusion
@@ -29,14 +29,18 @@
 (declare-function org-transclusion-within-transclusion-p
                   "org-transclusion")
 
+(add-hook 'org-transclusion-after-add-functions
+          #'org-translusion-indent-add-properties)
+
 (defun org-translusion-indent-add-properties (beg end)
   "BEG END."
-  (advice-add #'org-indent-set-line-properties
-              :override
-              #'org-transclusion-indent-set-line-properties-ad)
-  (org-indent-add-properties beg end)
-  (advice-remove #'org-indent-set-line-properties
-                 #'org-transclusion-indent-set-line-properties-ad))
+  (when org-indent-mode
+    (advice-add #'org-indent-set-line-properties
+                :override
+                #'org-transclusion-indent-set-line-properties-ad)
+    (org-indent-add-properties beg end)
+    (advice-remove #'org-indent-set-line-properties
+                   #'org-transclusion-indent-set-line-properties-ad)))
 
 (defun org-transclusion-indent-set-line-properties-ad (level indentation &optional heading)
   "Set prefix properties on current line an move to next one.

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -43,9 +43,6 @@
 (require 'org-transclusion-font-lock)
 (require 'text-property-search)
 (require 'seq)
-(declare-function org-translusion-indent-add-properties
-                  "org-transclusion-indent-mode")
-(defvar org-indent-mode)
 
 ;;;; Customization
 
@@ -103,6 +100,17 @@ See `display-buffer' for example options."
   "Mode-line indicator for minor-mode variable `org-transclusion-mode'."
   :type '(choice (const :tag "No lighter" "") string)
   :safe 'stringp)
+
+(defcustom org-transclusion-after-add-functions nil
+  "Functions to be called after a transclusion content has been added.
+The hook runs after the content and the read-only text property
+have been added so it is not supposed to manipulate the content
+but to add further text properties.  For example, it is used by
+the `org-transclusion-indent-mode' extension to support
+`org-indent-mode'.  The functions are called with arguments beg
+and end, pointing to the beginning and end of the transcluded
+content."
+  :type '(repeat function))
 
 ;;;; Faces
 
@@ -442,9 +450,7 @@ does not support all the elements.
               ;; `org-transclusion-keyword-remove' checks element at point is a
               ;; keyword or not
               (org-transclusion-keyword-remove)))
-          (when (and (featurep 'org-indent) org-indent-mode
-                     (memq 'org-transclusion-indent-mode org-transclusion-extensions))
-            (org-translusion-indent-add-properties beg end)))
+          (run-hook-with-args 'org-transclusion-after-add-functions beg end))
         t))))
 
 ;;;###autoload
@@ -521,11 +527,7 @@ When success, return the beginning point of the keyword re-inserted."
             ;; inevitably have the same position (location "between" lines)
             (when mkr-at-beg (move-marker mkr-at-beg beg))
             ;; Go back to the beginning of the inserted keyword line
-            (goto-char beg)
-            (when (and (featurep 'org-indent) org-indent-mode
-                       (memq 'org-transclusion-indent-mode
-                             org-transclusion-extensions))
-              (org-translusion-indent-add-properties beg (line-end-position))))
+            (goto-char beg))
           beg))
     (message "Nothing done. No transclusion exists here.") nil))
 

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -17,7 +17,7 @@
 
 ;; Author:        Noboru Ota <me@nobiot.com>
 ;; Created:       10 October 2020
-;; Last modified: 06 January 2022
+;; Last modified: 07 January 2022
 
 ;; URL: https://github.com/nobiot/org-transclusion
 ;; Keywords: org-mode, transclusion, writing
@@ -428,7 +428,7 @@ does not support all the elements.
                    "No content found with \"%s\".  Check the link at point %d, line %d"
                    (org-element-property :raw-link link) (point) (org-current-line))
                   nil))
-        (let ((beg (point))
+        (let ((beg (line-beginning-position))
               (end))
           (org-transclusion-with-inhibit-read-only
             (when (save-excursion

--- a/test/test-2.0.org
+++ b/test/test-2.0.org
@@ -18,6 +18,10 @@ t/nil will be dropped after remove-at-point
 
 (setq inhibit-read-only nil)
 
+** test
+
+#+transclude: [[file:bertrand-russell.org::*Bertrand Russell - Wikipedia]] :level 1 
+
 ** Test =org-adapt-indentation=
 
 #+begin_example


### PR DESCRIPTION
Refer to discussions in PR #119.

A new abnormal hook, `org-transclusion-after-add-functions` has been added.

"Functions to be called after a transclusion content has been added.  The hook
runs after the content and the read-only text property have been added so it is
not supposed to manipulate the content but to add further text properties.  For
example, it is used by the `org-transclusion-indent-mode' extension to support
`org-indent-mode'.  The functions are called with arguments beg and end,
pointing to the beginning and end of the transcluded content."

The existing extension, `org-transclusion-indent-mode` has been refactored to
use the newly added hook.  In this refactoring, the part which existed in the
remove function has been removed and tested OK to do so.

Documentation is WIP and to be added before a new version makes its way to ELPA.
