### PR TITLE
fix:#131: Transclusion respects indent level for non-Org text files

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,10 @@
+* Current
+
+  - Fix: #131. For non-Org files, now the transcluded text respects the indent
+         level of the #+transclude keyword.  This does not affect Org files.
+
 * Version 1.2.0
+
   - Feature ::
 
     - add: org-transclusion-after-add-hook

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -17,7 +17,7 @@
 
 ;; Author:        Noboru Ota <me@nobiot.com>
 ;; Created:       10 October 2020
-;; Last modified: 13 January 2022
+;; Last modified: 29 January 2022
 
 ;; URL: https://github.com/nobiot/org-transclusion
 ;; Keywords: org-mode, transclusion, writing
@@ -966,7 +966,8 @@ based on the following arguments:
             (setq content (buffer-string)))))
     (insert
      (run-hook-with-args-until-success
-      'org-transclusion-content-format-functions type content))
+      'org-transclusion-content-format-functions
+      type content (plist-get keyword-values :current-indentation)))
     (setq end (point))
     (setq end-mkr (set-marker (make-marker) end))
     (add-text-properties beg end
@@ -1015,7 +1016,7 @@ This function sssumes the buffer is an Org buffer."
         (push (org-element-property :level h) list)))
     (when list (seq-min list))))
 
-(defun org-transclusion-content-format-org (type content)
+(defun org-transclusion-content-format-org (type content _indent)
   "Format text CONTENT from source before transcluding.
 Return content modified (or unmodified, if not applicable).
 
@@ -1040,14 +1041,17 @@ content."
       ;; Return the temp-buffer's string
       (buffer-string)))))
 
-(defun org-transclusion-content-format (_type content)
+(defun org-transclusion-content-format (_type content indent)
   "Format text CONTENT from source before transcluding.
 Return content modified (or unmodified, if not applicable).
 
-This is the default one.  It only returns the content as is."
+This is the default one.  It only returns the content as is.
+
+INDENT is the number of current indentation of the #+transclude."
   (with-temp-buffer
     (insert content)
     ;; Return the temp-buffer's string
+    (set-left-margin (point-min)(point-max) indent)
     (buffer-string)))
 
 (defun org-transclusion-content-org-marker (marker plist)

--- a/test/test-2.0.org
+++ b/test/test-2.0.org
@@ -1,20 +1,20 @@
 * Regression
 ** make from link
 This is a link to a [[id:20210501T171427.051019][Bertrand Russell]] wikipedia excerpt
-#+transclude: [[id:fac76146-492c-4541-9540-91707b945f2c][Bertrand Russell]] 
+#+transclude: [[id:20210501T171427.051019][Bertrand Russell]] 
 
 ** test empty file
 #+transclude: [[file:empty.txt::2][empty text file]]
 
 ** test text
-#+transclude: [[file:test.txt][text file]]
+#+transclude: [[file:test.txt][text file]] 
 
 ** test t/nil
 t/nil will be dropped after remove-at-point
 
 
-#+transclude: [[file:test.txt][text file]]
-#+transclude: t [[id:20210501T171427.051019][Bertrand Russell]]
+#+transclude: [[file:test.txt][text file]] 
+#+transclude: t [[id:20210501T171427.051019][Bertrand Russell]] 
 
 (setq inhibit-read-only nil)
 
@@ -29,32 +29,31 @@ t/nil will be dropped after remove-at-point
 (setq org-adapt-indentation t)
 #+end_example
 
-#+transclude: [[id:20210501T171427.051019][Bertrand Russell]]
+#+transclude: [[id:20210501T171427.051019][Bertrand Russell]] 
 
 ** Paragraph
 
-
-#+transclude: [[file:./paragraph.org::para1]]
+#+transclude: [[file:./paragraph.org::para1]] 
 
 #+transclude: [[file:./paragraph.org::para2]] 
 
 ** Table
-#+transclude: [[file:paragraph.org::table][Link to a table]]
+#+transclude: [[file:paragraph.org::table][Link to a table]] 
 
 #+begin_example
 (variable-pitch-mode -1)
 #+end_example
 
-#+transclude: [[file:paragraph.org::table-with-link][Link to a table with a link]]
+#+transclude: [[file:paragraph.org::table-with-link][Link to a table with a link]] 
 
 ** Quote
-#+transclude: [[file:paragraph.org::quote][Link to a quote]]
+#+transclude: [[file:paragraph.org::quote][Link to a quote]] 
 
 ** #Custom ID
-#+transclude: [[file:testpara.org::#custom-id-1][Custom ID]] :level 2
+#+transclude: [[file:testpara.org::#custom-id-1][Custom ID]] :level 2 
 
 ** *Hadline
-#+transclude: [[file:bertrand-russell.org::*Bertrand Russell - Wikipedia]] :level 2 :disable-auto
+#+transclude: [[file:bertrand-russell.org::*Bertrand Russell - Wikipedia]] :level 2 :disable-auto 
 
 ** Filter
 
@@ -69,7 +68,7 @@ t/nil will be dropped after remove-at-point
 #+end_example
 
 [[file:./test-no-first-section.org]]
-#+ transclude: [[file:./test-no-first-section.org]]
+#+transclude: [[file:./test-no-first-section.org]] 
 
 * Live-Sync
 ** center-block dynamic-block example-block export-block special-block verse-block
@@ -154,4 +153,16 @@ t/nil will be dropped after remove-at-point
 
 * Open Source
 #+transclude: [[file:open.org]]
+
+* Issue #131 - Level one
+
+1. First item
+
+   Text associated with the first item.
+   
+   #+transclude: [[file:paragraph.txt][link]] 
+
+2. Second item
+
+* Level two
 


### PR DESCRIPTION
For non-Org files only, now the transcluded text respects the indent level of
the #+transclude keyword.  This does not affect Org files.