### PR TITLE
Dev/detach to address #152

### DIFF
--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -1,6 +1,6 @@
 ;;; org-transclusion.el --- Transclude text content via links -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021-2022  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2023  Free Software Foundation, Inc.
 
 ;; This program is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by the
@@ -17,7 +17,7 @@
 
 ;; Author:        Noboru Ota <me@nobiot.com>
 ;; Created:       10 October 2020
-;; Last modified: 12 June 2022
+;; Last modified: 03 February 2023
 
 ;; URL: https://github.com/nobiot/org-transclusion
 ;; Keywords: org-mode, transclusion, writing

--- a/test/test-2.0.org
+++ b/test/test-2.0.org
@@ -2,7 +2,6 @@
 ** make from link
 This is a link to a [[id:20210501T171427.051019][Bertrand Russell]] wikipedia excerpt
 #+transclude: [[id:20210501T171427.051019][Bertrand Russell]] 
-
 ** test empty file
 #+transclude: [[file:empty.txt::2][empty text file]]
 
@@ -165,4 +164,9 @@ t/nil will be dropped after remove-at-point
 2. Second item
 
 * Level two
+* Test headlines only
+
+#+transclude: [[id:2022-06-26T141859]] :exclude-elements "paragraph" 
+
+#+transclude: [[id:2022-06-26T141859]] 
 


### PR DESCRIPTION
- New command 'org-transclusion-detach' can be used on the transclusion
  at point. It turns it into a normal, edtitable text content.

  You can undo this operation.

  In addition, you can press 'C-d' directly on the transclusion at point
  to detach it.  This is because the command is bound to 'C-d' by
  default in 'org-transclusion-map'.

- 'org-transclusion-refresh' now accepts universal argument such as
  'C-u M-x org-transclusion-refresh' and detaches the transclusion at
  point.

- 'org-transclusion-add' now accepts universal argument such as 'C-u M-x
  org-transclusion-add' and copies the source content rather than
  transclude it.

  You can undo this operation.

- Limitation: Undo detach does not add the overlay back on the
  source. This should not break any feature. You can safely refresh the
  transclusion and recover the source overlay. You can also safely open
  or moved to the source.