### PR TITLE
fix: (unit-tests.el) require org-transclusion

### DIFF
--- a/test/unit-tests.el
+++ b/test/unit-tests.el
@@ -2,6 +2,7 @@
 ;; org-transclusion unit tests
 ;; To run the tests you can use: M-x ert RET t RET
 ;; You can read more about ert here: https://www.gnu.org/software/emacs/manual/html_node/ert/index.html
+(require 'org-transclusion)
 
 (ert-deftest org-transclusion-org-file-p-test ()
   "Tests org-transclusion-org-file-p against string inputs."


### PR DESCRIPTION
Resolves:

unit-tests.el:8:19: Warning: the function `org-transclusion-org-file-p' is not known to be defined.