### PR TITLE
fix: (org-transclusion-src-lines.el) require org-transclusion

### DIFF
--- a/org-transclusion-src-lines.el
+++ b/org-transclusion-src-lines.el
@@ -314,6 +314,7 @@ match any valid elisp symbol (but please don't quote it)."
   (when (string-match ":thing-at-point \\([[:alnum:][:punct:]]+\\)" string)
     (list :thing-at-point (org-strip-quotes (match-string 1 string)))))
 
+(declare-function org-transclusion-content-format "org-transclusion")
 (defun org-transclusion-content-format-src-lines (type content indent)
   "Format text CONTENT from source before transcluding.
 Return content modified (or unmodified, if not applicable).


### PR DESCRIPTION
This ensures that org-transclusion-content-format is defined.

(my FSF copyright assignment paperwork has been accepted)