### PR TITLE
Don't ever prompt to create a headline when transcluding 

### DIFF
--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -1119,7 +1119,12 @@ work to
     ;; search-option is present.
     (let* ((path (org-element-property :path link))
            (search-option (org-element-property :search-option link))
-           (buf (find-file-noselect path)))
+           (buf (find-file-noselect path))
+           (org-link-search-must-match-exact-headline
+            ;; Don't ever prompt to create a headline when transcluding
+            (if (eq 'query-to-create org-link-search-must-match-exact-headline)
+                t  ;; Less surprising default than nil - fuzzy search
+              org-link-search-must-match-exact-headline)))
       (with-current-buffer buf
         (org-with-wide-buffer
          (if search-option

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -1127,13 +1127,12 @@ work to
               org-link-search-must-match-exact-headline)))
       (with-current-buffer buf
         (org-with-wide-buffer
-         (if search-option
-             (progn
-               (org-link-search search-option)
-               (org-transclusion-content-org-buffer-or-element
-                'only-element plist))
-           (org-transclusion-content-org-buffer-or-element
-            nil plist)))))))
+         (org-transclusion-content-org-buffer-or-element
+          (and search-option
+               (progn
+                 (org-link-search search-option)
+                 t))
+          plist))))))
 
 (defun org-transclusion-content-org-buffer-or-element (only-element plist)
   "Return a list of playload for transclusion.


### PR DESCRIPTION
The default setting of `org-link-search-must-match-exact-headline`
causes Emacs to prompt the user to create a new heading when a link
target is not found.

This commit temporarily overrides the default setting to signal an
error when no headline exactly matches the link target.  Since errors
are demoted, this skips the failed transclusion.

However, if the user has set
`org-link-search-must-match-exact-headline` to perform a fuzzy search
for link targets, we don't override the option.