### PR TITLE
Use org-export-before-processing-functions if available

### DIFF
--- a/org-transclusion-src-lines.el
+++ b/org-transclusion-src-lines.el
@@ -52,7 +52,7 @@
 (add-hook 'org-transclusion-keyword-plist-to-string-functions
           #'org-transclusion-keyword-plist-to-string-src-lines)
 
-;; Transclusion content formating
+;; Transclusion content formatting
 (add-hook 'org-transclusion-content-format-functions
           #'org-transclusion-content-format-src-lines)
 
@@ -143,7 +143,7 @@ it means from line 10 to the end of file."
                                (save-excursion
                                  (ignore-errors
                                    ;; FIXME `org-link-search' does not
-                                   ;; return postion when eithher
+                                   ;; return position when eithher
                                    ;; ::/regex/ or ::number is used
                                    (if (org-link-search search-option)
                                        (line-beginning-position))))))
@@ -160,7 +160,7 @@ it means from line 10 to the end of file."
                                   (save-excursion
                                     (ignore-errors
                                       ;; FIXME `org-link-search' does not
-                                      ;; return postion when either ::/regex/
+                                      ;; return position when either ::/regex/
                                       ;; or ::number is used
                                       (when (org-link-search end-search-op)
                                         (line-beginning-position))))))))

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -312,7 +312,9 @@ and variables."
   (add-hook 'after-save-hook #'org-transclusion-after-save-buffer nil t)
   (add-hook 'kill-buffer-hook #'org-transclusion-before-kill nil t)
   (add-hook 'kill-emacs-hook #'org-transclusion-before-kill nil t)
-  (add-hook 'org-export-before-processing-hook
+  (add-hook (if (version< org-version "9.6")
+                'org-export-before-processing-hook
+              'org-export-before-processing-functions)
             #'org-transclusion-inhibit-read-only nil t)
   (org-transclusion-yank-excluded-properties-set)
   (org-transclusion-load-extensions-maybe))
@@ -326,7 +328,9 @@ This function also removes all the transclusions in the current buffer."
   (remove-hook 'after-save-hook #'org-transclusion-after-save-buffer t)
   (remove-hook 'kill-buffer-hook #'org-transclusion-before-kill t)
   (remove-hook 'kill-emacs-hook #'org-transclusion-before-kill t)
-  (remove-hook 'org-export-before-processing-hook
+  (remove-hook (if (version< org-version "9.6")
+                   'org-export-before-processing-hook
+                 'org-export-before-processing-functions)
                #'org-transclusion-inhibit-read-only t)
   (org-transclusion-yank-excluded-properties-remove))
 

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -177,7 +177,7 @@ a text content.
 `org-transclusion-after-save-buffer' use this variable.")
 
 (defvar-local org-transclusion-remember-window-config nil
-  "Remember window config (the arrangment of windows) for the current buffer.
+  "Remember window config (the arrangement of windows) for the current buffer.
 This is for live-sync.  Analogous to
 `org-edit-src-code'.")
 
@@ -271,7 +271,7 @@ specific keybindings; namely:
   nil nil '(center t))
 
 ;;;; Macro
-;;;; Definining macros before they are used in the rest of package
+;;;; Defining macros before they are used in the rest of package
 ;;;; Flycheck warns with "macro X defined too late"
 (defmacro org-transclusion-with-inhibit-read-only (&rest body)
   "Run BODY with `'inhibit-read-only` t."
@@ -320,7 +320,7 @@ and variables."
   (org-transclusion-load-extensions-maybe))
 
 (defun org-transclusion-deactivate ()
-  "Dectivate Org-transclusion hooks and other setups in the current buffer.
+  "Deactivate Org-transclusion hooks and other setups in the current buffer.
 This function also removes all the transclusions in the current buffer."
   (interactive)
   (org-transclusion-remove-all)
@@ -697,7 +697,7 @@ a couple of org-transclusion specific keybindings; namely:
 
 (defun org-transclusion-live-sync-exit ()
   "Exit live-sync at point.
-It attemps to re-arrange the windows for the current buffer to
+It attempts to re-arrange the windows for the current buffer to
 the state before live-sync started."
   (interactive)
   (if (not (org-transclusion-within-live-sync-p))
@@ -721,7 +721,7 @@ This is meant to be used within live-sync overlay as part of
 
 ;;;;---------------------------------------------------------------------------
 ;;;; Private Functions
-;;;; Functions for Activate / Deactiveate / save-buffer hooks
+;;;; Functions for Activate / Deactivate / save-buffer hooks
 
 (defun org-transclusion-before-save-buffer ()
   "Remove translusions in `before-save-hook'.
@@ -904,7 +904,7 @@ keyword.  If not, returns nil."
   "Return list of symbols from PLIST when applicable.
 If PLIST does not have :exclude-elements, return nil.
 
-This function also attemps to remove empty string that gets
+This function also attempts to remove empty string that gets
 inserted when more than one space is inserted between symbols."
   (let ((str (plist-get plist :exclude-elements)))
     (when str
@@ -1119,7 +1119,7 @@ This function is intended to be used for Org-ID.  It delates the
 work to
 `org-transclusion-content-org-buffer-or-element'."
   (save-excursion
-    ;; First visit the buffer and go to the relevant elelement if
+    ;; First visit the buffer and go to the relevant element if
     ;; search-option is present.
     (let* ((path (org-element-property :path link))
            (search-option (org-element-property :search-option link))
@@ -1406,7 +1406,7 @@ It is intended to be used for `org-transclusion-open-source' and
 This function relies on `org-transclusion-find-source-marker' to
 locate the position in the source buffer; thus, the same
 limitation applies.  It depends on which org elements whether or
-not this function can identify the beginnning of the element at
+not this function can identify the beginning of the element at
 point.  If it cannot, it will return the beginning of the
 transclusion, which can be far away from the element at point, if
 the transcluded region is large."
@@ -1550,7 +1550,7 @@ transclusion in this structure:
 
 (defun org-transclusion-live-sync-display-buffer (buffer)
   "Display the source buffer upon entering live-sync edit.
-It rembembers the current arrangement of windows (window
+It remembers the current arrangement of windows (window
 configuration), deletes the other windows, and displays
 BUFFER (intended to be the source buffer being edited in
 live-sync.)

--- a/test/things-at-point-dir/story.txt
+++ b/test/things-at-point-dir/story.txt
@@ -1,5 +1,5 @@
 This is a story
 
-Once upon a time. This paragraph should be transcluded. This is a story. And if I have a hard line break, I belive this line is still part of the paragraph as defined by ... thing-at-point I think.
+Once upon a time. This paragraph should be transcluded. This is a story. And if I have a hard line break, I believe this line is still part of the paragraph as defined by ... thing-at-point I think.
 
 This is a new paragraph and should not be included.

--- a/text-clone.el
+++ b/text-clone.el
@@ -30,7 +30,7 @@
 
 ;;;; Credits
 
-;; It is an extention of text-clone functions written as part of GNU Emacs in
+;; It is an extension of text-clone functions written as part of GNU Emacs in
 ;; subr.el.  The first adaption to extend text-clone functions to work across
 ;; buffers was published in StackExchange by the user named Tobias in March
 ;; 2020. It can be found at https://emacs.stackexchange.com/questions/56201/
@@ -48,7 +48,7 @@
 overlays.  Used primarily by `text-clone-delete-overlays'.")
 
 (defvar text-clone-live-sync-in-progress nil
-  "Global varible used by `text-clone-live-sync' function.")
+  "Global variable used by `text-clone-live-sync' function.")
 
 ;;;; Functions
 
@@ -70,7 +70,7 @@ which is primarily used to clean up text-clone overlays with
 `text-clone-delete-overlays'.
 
 This function does not explicitly differentiate overlays for the
-orginal text region and its clones.  Where such distinction is
+original text region and its clones.  Where such distinction is
 important, use the sequence of OVERLAYS list; for example, the
 first element of the list can be the overlay for the original and
 rest, clones.
@@ -150,7 +150,7 @@ This is used on the `modification-hooks' property of text clones.
 AFTER, BEG, and END are the fixed args for `modification-hooks'
 and friends in an overlay.
 
-It's a simplified version of the orignal `text-clone--maintain'.
+It's a simplified version of the original `text-clone--maintain'.
 This function does not use SPREADP or SYNTAX (both defined in
 `text-clone-create').
 


### PR DESCRIPTION
This hook variable was renamed in [1: fe90cab95].

1: 2022-09-06 fe90cab9564bd6fa08c9abe0882e0e06cc5626f9
   lisp/ox.el: Rename abnormal hook names to end with "-functions"