### PR TITLE
docs: Note missing asynchronous functionality

### DIFF
--- a/docs/org-transclusion-manual.org
+++ b/docs/org-transclusion-manual.org
@@ -195,14 +195,21 @@ It is generally assumed that the =paragraph-id= is placed after its content, but
 
 For the =:only-contents= property, refer to sub-section [[#filtering-org-elements-per-transclusion][Filtering Org elements per transclusion]].
 
-** Links with hyper://, http://, and other protocols
+** Links with ~hyper://~, ~http://~, and other protocols
 :PROPERTIES:
 :CUSTOM_ID: other-protocols
 :END:
 #+cindex: Links with hyper://, http://, and other protocols
 
-With version 1.4, a transclusion works with hyper:// links (see [[https://git.sr.ht/~ushin/hyperdrive.el][hyperdrive.el]])
-or http:// links. Splitting the org-transclusion-add into two parts enables  functions in org-transclusion-add-functions to be asynchronous. With this change, content can be transcluded over a network, using http://, hyper://, or other protocols. For a proof-of-concept integration with hyperdrive.el, see [[https://git.sr.ht/~ushin/hyperdrive.el/tree/org-transclusion/item/hyperdrive-org-transclusion.el][this file]].
+With version 1.4, a transclusion works with ~hyper://~ links (see
+[[https://git.sr.ht/~ushin/hyperdrive.el][hyperdrive.el]]) or ~http://~ links.  Splitting ~org-transclusion-add~ into
+two parts enables functions in ~org-transclusion-add-functions~ to be
+asynchronous.  With this change, content can be transcluded over a
+network, using ~http://~, ~hyper://~, or other protocols.  For a
+proof-of-concept integration with ~hyperdrive.el~, see [[https://git.sr.ht/~ushin/hyperdrive.el/tree/org-transclusion/item/hyperdrive-org-transclusion.el][this file]].
+Currently only ~org-transclusion-add~ is fully supported; features like
+live-syncing and opening source buffers are not implemented for
+asynchronous transclusions yet.
 
 [We expect more information and examples to be added for this section]
 

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -606,7 +606,9 @@ the rest of the buffer unchanged."
       list)))
 
 (defun org-transclusion-refresh (&optional detach)
-  "Refresh the transcluded text at point."
+  "Refresh the transcluded text at point.
+
+TODO: Support asynchronous transclusions (set point correctly)."
   (interactive "P")
   (when (org-transclusion-within-transclusion-p)
     (let ((pos (point)))
@@ -628,7 +630,10 @@ the rest of the buffer unchanged."
 (defun org-transclusion-open-source (&optional arg)
   "Open the source buffer of transclusion at point.
 When ARG is non-nil (e.g. \\[universal-argument]), the point will
-remain in the source buffer for further editing."
+remain in the source buffer for further editing.
+
+TODO: Support asynchronous transclusions when source buffer
+doesn't exist."
   (interactive "P")
   (unless (overlay-buffer (get-text-property (point) 'org-transclusion-pair))
     (org-transclusion-refresh))
@@ -684,7 +689,9 @@ a couple of org-transclusion specific keybindings; namely:
 - `org-transclusion-live-sync-paste'
 - `org-transclusion-live-sync-exit'
 
-\\{org-transclusion-live-sync-map}"
+\\{org-transclusion-live-sync-map}
+
+TODO: Support asynchronous transclusions."
   (interactive)
   (if (not (org-transclusion-within-transclusion-p))
       (progn (message (format "Nothing done. Not a translusion at %d" (point)))


### PR DESCRIPTION
For now, I think this is sufficient to let users know that async transclusion isn't currently supported by some `org-transclusion` commands.