### PR TITLE
Fix: (org-transclusion-add-html-file) Use "org-html-file" tc-type

### DIFF
--- a/org-transclusion-html.el
+++ b/org-transclusion-html.el
@@ -52,7 +52,7 @@ Return nil if not found."
            (with-current-buffer (find-file-noselect
                                  (org-element-property :path link) t)
              (org-transclusion-html--html-p (current-buffer))))
-       (append '(:tc-type "html-org-file")
+       (append '(:tc-type "org-html-file")
                (org-transclusion-html-org-file-content link plist))))
 
 (defun org-transclusion-html-org-file-content (link _plist)


### PR DESCRIPTION
Some org-transclusion features for Org mode, such as :level, expect tc-type to begin with "org".  See `org-transclusion-type-is-org` and its usage for details.