### PR TITLE
fix: #177 Infinite loop when saving buffer with transclusions

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,48 @@
+* 1.4.1 (2024-12-29)
+
+  - Fixes ::
+
+    fix: #177 Infinite loop when saving buffer with transclusions
+
+         Fixing a long-lasting (issue open since March 2023, but it had been an
+         known issue before it) issue that was difficult to reproduce.
+
+         The fix is to stop using the text-properties of the transclusion that
+         hold markers of beginning and ending points of itself, which is meant
+         to remember and indicate its own the location; or the range of "this"
+         transclusion at point. The text-properties are named
+         `org-transclusion-beg-mkr' and `org-transclusion-end-mkr'. They are
+         replaced with use of a new text-property `org-transclusion-id' and
+         function `org-transclusion-at-point'. This new function uses
+         `prop-match' with `org-transclusion-id' to identify the range of "this"
+         transclusion at point only when it is needed, thus eliminating the need
+         for memorizing it as a pair of markers.
+
+         Stable reproduction was achieved and recorded in a comment to the GitHub
+         issue at
+         https://github.com/nobiot/org-transclusion/issues/177#issuecomment-2108453402.
+
+         A quick summary of the design hitherto and how the infinite loop occurs
+         is as follows:
+
+         [Fact / design of org-transclusion]
+
+         - Each transclusion has text-properties org-transclusion-beg-mkr and
+           org-transclusion-end-mkr.
+
+         - They hold markers to keep track of where the transclusion begins and
+           ends.
+
+         [Now what happens]
+
+         - In some combination of undo and buffer-save with transclusions, the
+           markers can temporarily point to non-existing locations in the
+           buffer.
+
+         - If the garbage collection happens to run at this moment, it will
+           sweep these pointers. Now they end up pointing to start of the buffer
+           (point 1).
+
 * 1.4.0 (2024-05-20)
 
   - Features ::

--- a/org-transclusion-src-lines.el
+++ b/org-transclusion-src-lines.el
@@ -17,7 +17,7 @@
 
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; Created: 24 May 2021
-;; Last modified: 21 January 2024
+;; Last modified: 27 December 2024
 
 ;;; Commentary:
 ;;  This is an extension to `org-transclusion'.  When active, it adds features
@@ -281,7 +281,9 @@ Return nil if neither."
   "Return marker for `org-transclusion-open-source'.
 Use TYPE to check relevance."
   (when (org-transclusion-src-lines-p type)
-    (get-text-property (point) 'tc-src-beg-mkr)))
+    (let ((ov (get-char-property (point)
+                                 'org-transclusion-pair)))
+      (move-marker (make-marker) (overlay-start ov) (overlay-buffer ov)))))
 
 (defun org-transclusion-live-sync-buffers-src-lines (type)
   "Return cons cell of overlays for source and trasnclusion.

--- a/test/test-2.0.org
+++ b/test/test-2.0.org
@@ -240,3 +240,22 @@ This is content of H3
 #+transclude: [[id:2022-06-26T141859]] :exclude-elements "paragraph"
 
 #+transclude: [[id:2022-06-26T141859]]
+* Test src
+
+#+transclude: [[file:./python-1.py]]
+#+transclude: [[file:./python-1.py]]  :src python
+
+#+begin_src python
+  import matplotlib
+  import matplotlib.pyplot as plt
+  # end here
+  # id-1234
+  fig=plt.figure(figsize=(9,6))
+  plt.plot([1,3,2])
+  fig.tight_layout()
+  fname = 'pyfig2.png'
+  plt.savefig(fname)
+  # id-1234 end here
+  return fname # return this to org-mode
+#+end_src
+


### PR DESCRIPTION
Fixing a long-lasting (issue open since March 2023, but it had been an known issue before it) issue that was difficult to reproduce.

The fix is to stop using the text-properties of the transclusion that hold markers of beginning and ending points of itself, which is meant to remember and indicate its own the location; or the range of "this" transclusion at point. The text-properties are named `org-transclusion-beg-mkr' and `org-transclusion-end-mkr'. They are replaced with use of a new text-property `org-transclusion-id' and function `org-transclusion-at-point'. This new function uses `prop-match' with `org-transclusion-id' to identify the range of "this" transclusion at point only when it is needed, thus eliminating the need for memorizing it as a pair of markers.

Stable reproduction was achieved and recorded in a comment to the GitHub issue at https://github.com/nobiot/org-transclusion/issues/177#issuecomment-2108453402.

A quick summary of the design hitherto and how the infinite loop occurs is as follows:

[Fact / design of org-transclusion]

- Each transclusion has text-properties org-transclusion-beg-mkr and org-transclusion-end-mkr.

- They hold markers to keep track of where the transclusion begins and ends.

[Now what happens]

- In some combination of undo and buffer-save with transclusions, the markers can temporarily point to non-existing locations in the buffer.

- If the garbage collection happens to run at this moment, it will sweep these pointers. Now they end up pointing to start of the buffer (point 1).

docs: Update NEWS