### PR TITLE
fix: Remove unused lexical variable

### DIFF
--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -587,7 +587,7 @@ the rest of the buffer unchanged."
   (interactive "P")
   (save-restriction
     (let ((current-marker (move-marker (make-marker) (point)))
-          match removed-marker list)
+          match list)
       (unless narrowed (widen))
       (goto-char (point-min))
       (while (setq match (text-property-search-forward 'org-transclusion-id))


### PR DESCRIPTION
In [1: f6fd666] we stopped using this lexical variable.