### PR TITLE
chg: Make hooks to set up extensions removable #261

### DIFF
--- a/org-transclusion-font-lock.el
+++ b/org-transclusion-font-lock.el
@@ -1,6 +1,6 @@
 ;;; org-transclusion-font-lock.el --- font-lock for Org-transclusion -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021-2024  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2025  Free Software Foundation, Inc.
 
 ;; This program is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by the
@@ -17,7 +17,7 @@
 
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; Created: 22 August 2021
-;; Last modified: 21 January 2024
+;; Last modified: 02 January 2025
 
 ;;; Commentary:
 ;;  This file is part of Org-transclusion
@@ -26,7 +26,26 @@
 ;;; Code:
 
 (require 'org)
-(add-hook 'org-font-lock-set-keywords-hook #'org-transclusion-font-lock-set)
+(require 'org-transclusion)
+
+;;;###autoload
+(define-minor-mode org-transclusion-font-lock-mode ()
+  :lighter nil
+  :global t
+  :group 'org-transclusion
+  (if org-transclusion-font-lock-mode
+      (org-transclusion-extension-functions-add-or-remove
+       org-transclusion-font-lock-extension-functions)
+    (org-transclusion-extension-functions-add-or-remove
+     org-transclusion-font-lock-extension-functions :remove)))
+
+(defvar org-transclusion-font-lock-extension-functions
+  '((cons 'org-font-lock-set-keywords-hook #'org-transclusion-font-lock-set))
+  "Alist of functions to activate `org-transclusion-font-lock'.
+CAR of each cons cell is a symbol name of an abnormal hook
+\(*-functions\). CDR is either a symbol or list of symbols, which
+are names of functions to be called in the corresponding abnormal
+hook.")
 
 (defface org-transclusion-keyword
   '((((class color) (min-colors 88) (background light))

--- a/org-transclusion-font-lock.el
+++ b/org-transclusion-font-lock.el
@@ -40,7 +40,7 @@
      org-transclusion-font-lock-extension-functions :remove)))
 
 (defvar org-transclusion-font-lock-extension-functions
-  '((cons 'org-font-lock-set-keywords-hook #'org-transclusion-font-lock-set))
+  (list (cons 'org-font-lock-set-keywords-hook #'org-transclusion-font-lock-set))
   "Alist of functions to activate `org-transclusion-font-lock'.
 CAR of each cons cell is a symbol name of an abnormal hook
 \(*-functions\). CDR is either a symbol or list of symbols, which

--- a/org-transclusion-html.el
+++ b/org-transclusion-html.el
@@ -52,7 +52,7 @@
      org-transclusion-html-extension-functions :remove)))
 
 (defvar org-transclusion-html-extension-functions
-  '((cons 'org-transclusion-add-functions #'org-transclusion-html-add-file))
+  (list (cons 'org-transclusion-add-functions #'org-transclusion-html-add-file))
   "Alist of functions to activate `org-transclusion-html'.
 CAR of each cons cell is a symbol name of an abnormal hook
 \(*-functions\). CDR is either a symbol or list of symbols, which

--- a/org-transclusion-html.el
+++ b/org-transclusion-html.el
@@ -1,6 +1,6 @@
 ;;; org-transclusion-html.el --- Converting HTML content to Org -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024  Free Software Foundation, Inc.
+;; Copyright (C) 2024-2025 Free Software Foundation, Inc.
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU Affero General Public License
@@ -31,6 +31,7 @@
 
 ;;;; Requirements
 
+(require 'org-transclusion)
 (require 'org)
 (require 'org-element)
 (require 'cl-lib)
@@ -39,7 +40,24 @@
 
 ;;;; Hook into org-transclusion
 
-(add-hook 'org-transclusion-add-functions #'org-transclusion-html-add-file)
+;;;###autoload
+(define-minor-mode org-transclusion-html-mode ()
+  :lighter nil
+  :global t
+  :group 'org-transclusion
+  (if org-transclusion-html-mode
+      (org-transclusion-extension-functions-add-or-remove
+       org-transclusion-html-extension-functions)
+    (org-transclusion-extension-functions-add-or-remove
+     org-transclusion-html-extension-functions :remove)))
+
+(defvar org-transclusion-html-extension-functions
+  '((cons 'org-transclusion-add-functions #'org-transclusion-html-add-file))
+  "Alist of functions to activate `org-transclusion-html'.
+CAR of each cons cell is a symbol name of an abnormal hook
+\(*-functions\). CDR is either a symbol or list of symbols, which
+are names of functions to be called in the corresponding abnormal
+hook.")
 
 ;;;; Functions
 

--- a/org-transclusion-indent-mode.el
+++ b/org-transclusion-indent-mode.el
@@ -42,8 +42,8 @@
      org-transclusion-indent-extension-functions :remove)))
 
 (defvar org-transclusion-indent-extension-functions
-  '((cons 'org-transclusion-after-add-functions
-          #'org-translusion-indent-add-properties))
+  (list (cons 'org-transclusion-after-add-functions
+              #'org-translusion-indent-add-properties))
   "Alist of functions to activate `org-transclusion-indent-mode'.
 CAR of each cons cell is a symbol name of an abnormal hook
 \(*-functions\). CDR is either a symbol or list of symbols, which

--- a/org-transclusion-indent-mode.el
+++ b/org-transclusion-indent-mode.el
@@ -1,6 +1,6 @@
 ;;; org-transclusion-indent-mode.el --- support org-indent-mode -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021-2024  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2025  Free Software Foundation, Inc.
 
 ;; This program is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by the
@@ -17,7 +17,7 @@
 
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; Created: 22 August 2021
-;; Last modified: 21 January 2024
+;; Last modified: 02 January 2025
 
 ;;; Commentary:
 ;;  This file is part of Org-transclusion
@@ -25,12 +25,30 @@
 
 ;;; Code:
 
+(require 'org-transclusion)
 (require 'org-indent)
 (declare-function org-transclusion-within-transclusion-p
                   "org-transclusion")
 
-(add-hook 'org-transclusion-after-add-functions
-          #'org-translusion-indent-add-properties)
+;;;###autoload
+(define-minor-mode org-transclusion-indent-mode ()
+  :lighter nil
+  :global t
+  :group 'org-transclusion
+  (if org-transclusion-indent-mode
+      (org-transclusion-extension-functions-add-or-remove
+       org-transclusion-indent-extension-functions)
+    (org-transclusion-extension-functions-add-or-remove
+     org-transclusion-indent-extension-functions :remove)))
+
+(defvar org-transclusion-indent-extension-functions
+  '((cons 'org-transclusion-after-add-functions
+          #'org-translusion-indent-add-properties))
+  "Alist of functions to activate `org-transclusion-indent-mode'.
+CAR of each cons cell is a symbol name of an abnormal hook
+\(*-functions\). CDR is either a symbol or list of symbols, which
+are names of functions to be called in the corresponding abnormal
+hook.")
 
 (defun org-translusion-indent-add-properties (beg end)
   "BEG END."

--- a/org-transclusion-src-lines.el
+++ b/org-transclusion-src-lines.el
@@ -1,6 +1,6 @@
 ;;; org-transclusion-src-lines.el --- Extension -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021-2024  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2025  Free Software Foundation, Inc.
 
 ;; This program is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by the
@@ -17,7 +17,7 @@
 
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; Created: 24 May 2021
-;; Last modified: 27 December 2024
+;; Last modified: 02 January 2025
 
 ;;; Commentary:
 ;;  This is an extension to `org-transclusion'.  When active, it adds features
@@ -25,6 +25,7 @@
 
 ;;; Code:
 
+(require 'org-transclusion)
 (require 'org-element)
 (declare-function text-clone-make-overlay "text-clone")
 (declare-function org-transclusion-live-sync-buffers-others-default
@@ -34,34 +35,45 @@
 
 ;;;; Setting up the extension
 
-;; Add a new transclusion type
-(add-hook 'org-transclusion-add-functions
-          #'org-transclusion-add-src-lines)
-;; Keyword values
-(add-hook 'org-transclusion-keyword-value-functions
-          #'org-transclusion-keyword-value-lines)
-(add-hook 'org-transclusion-keyword-value-functions
-          #'org-transclusion-keyword-value-src)
-(add-hook 'org-transclusion-keyword-value-functions
-          #'org-transclusion-keyword-value-rest)
-(add-hook 'org-transclusion-keyword-value-functions
-          #'org-transclusion-keyword-value-end)
-(add-hook 'org-transclusion-keyword-value-functions
-          #'org-transclusion-keyword-value-thing-at-point)
-;; plist back to string
-(add-hook 'org-transclusion-keyword-plist-to-string-functions
-          #'org-transclusion-keyword-plist-to-string-src-lines)
+;;;###autoload
+(define-minor-mode org-transclusion-src-lines-mode ()
+  :lighter nil
+  :global t
+  :group 'org-transclusion
+  (if org-transclusion-src-lines-mode
+      (org-transclusion-extension-functions-add-or-remove
+       org-transclusion-src-lines-extension-functions)
+    (org-transclusion-extension-functions-add-or-remove
+     org-transclusion-src-lines-extension-functions :remove)))
 
-;; Transclusion content formatting
-(add-hook 'org-transclusion-content-format-functions
-          #'org-transclusion-content-format-src-lines)
-
-;; Open source buffer
-(add-hook 'org-transclusion-open-source-marker-functions
-          #'org-transclusion-open-source-marker-src-lines)
-;; Live-sync
-(add-hook 'org-transclusion-live-sync-buffers-functions
-          #'org-transclusion-live-sync-buffers-src-lines)
+(defvar org-transclusion-src-lines-extension-functions
+  (list
+   ;; Add a new transclusion type
+   (cons 'org-transclusion-add-functions #'org-transclusion-add-src-lines)
+    ;; Keyword values
+   (cons 'org-transclusion-keyword-value-functions
+         '(org-transclusion-keyword-value-lines
+           org-transclusion-keyword-value-src
+           org-transclusion-keyword-value-rest
+           org-transclusion-keyword-value-end
+           org-transclusion-keyword-value-thing-at-point))
+   ;; plist back to string
+   (cons 'org-transclusion-keyword-plist-to-string-functions
+         #'org-transclusion-keyword-plist-to-string-src-lines)
+   ;; Transclusion content formatting
+   (cons 'org-transclusion-content-format-functions
+         #'org-transclusion-content-format-src-lines)
+   ;; Open source buffer
+   (cons 'org-transclusion-open-source-marker-functions
+         #'org-transclusion-open-source-marker-src-lines)
+   ;; Live-sync
+   (cons 'org-transclusion-live-sync-buffers-functions
+         #'org-transclusion-live-sync-buffers-src-lines))
+  "Alist of functions to activate `org-transclusion-src-lines'.
+CAR of each cons cell is a symbol name of an abnormal hook
+\(*-functions\). CDR is either a symbol or list of symbols, which
+are names of functions to be called in the corresponding abnormal
+hook.")
 
 ;;; Functions
 

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -42,7 +42,6 @@
 (require 'text-clone)
 (require 'text-property-search)
 (require 'seq)
-(require 'cl-macs) ; for cl-loop
 
 ;;;; Customization
 
@@ -1835,7 +1834,7 @@ ensure the settings revert to the user's setting prior to
   "Promote or demote transcluded subtree.
 When DEMOTE is non-nil, demote."
   (unless (org-transclusion-within-transclusion-p)
-    (user-error "Not in a transcluded headline."))
+    (user-error "Not in a transcluded headline"))
   (let* ((inhibit-read-only t)
          (beg (car (plist-get (org-transclusion-at-point) :location)))
          (pos (point)))


### PR DESCRIPTION
@josephmturner 

Wishing you a joyous New Year! Apologies for taking for so long to get back to you (I wanted to fix the infinite loop issue first...). I believe this is a good-enough fix. No breaking changes for users, and minor-modes can co-exist. The user manual need to be updated (especially how to use extensions -- on a separate issue, I am working on Transient-based menu UI in the background. 

Your -html.el is also adjusted based on this new way. Let me know what you think.

---

Added the  following utility functions to support the move

- `org-transclusion-extension-functions-add-or-remove`
- `org-transclusion-extension-set-a-hook-functions`

Modified function `org-transclusion-load-extensions-maybe` so that setting `org-transclusion-extensions` with the `customize` facilities will automatically activate the corresponding minor mode for each extension.

Use of `customize` and `org-transclusion-extensions` is optional. Users can ignore these and use extensions by loading and activating minor modes in their init.el file.

So, this below should work (each minor mode function has the autoload cookie, so the library should not have to be explicitly loaded).

```
(with-eval-after-load 'org-transclusion
    (org-transclusion-indent-mode +1))
 ```

Adding to the list and requiring the library like this below did not use to be
necessary...

```
(with-eval-after-load 'org-transclusion
     (add-to-list 'org-transclusion-extensions 'org-transclusion-indent-mode)
     (require 'org-transclusion-indent-mode))
```

The Customizing facility would load the active extension library with
`require`.... But I think this was never intuitive.