### PR TITLE
fix(add): org-id with search option #237

### DIFF
--- a/org-transclusion-font-lock.el
+++ b/org-transclusion-font-lock.el
@@ -1,6 +1,6 @@
 ;;; org-transclusion-font-lock.el --- font-lock for Org-transclusion -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021-2024  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2025  Free Software Foundation, Inc.
 
 ;; This program is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by the
@@ -17,7 +17,7 @@
 
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; Created: 22 August 2021
-;; Last modified: 21 January 2024
+;; Last modified: 02 January 2025
 
 ;;; Commentary:
 ;;  This file is part of Org-transclusion
@@ -26,7 +26,26 @@
 ;;; Code:
 
 (require 'org)
-(add-hook 'org-font-lock-set-keywords-hook #'org-transclusion-font-lock-set)
+(require 'org-transclusion)
+
+;;;###autoload
+(define-minor-mode org-transclusion-font-lock-mode ()
+  :lighter nil
+  :global t
+  :group 'org-transclusion
+  (if org-transclusion-font-lock-mode
+      (org-transclusion-extension-functions-add-or-remove
+       org-transclusion-font-lock-extension-functions)
+    (org-transclusion-extension-functions-add-or-remove
+     org-transclusion-font-lock-extension-functions :remove)))
+
+(defvar org-transclusion-font-lock-extension-functions
+  '((cons 'org-font-lock-set-keywords-hook #'org-transclusion-font-lock-set))
+  "Alist of functions to activate `org-transclusion-font-lock'.
+CAR of each cons cell is a symbol name of an abnormal hook
+\(*-functions\). CDR is either a symbol or list of symbols, which
+are names of functions to be called in the corresponding abnormal
+hook.")
 
 (defface org-transclusion-keyword
   '((((class color) (min-colors 88) (background light))

--- a/org-transclusion-font-lock.el
+++ b/org-transclusion-font-lock.el
@@ -40,7 +40,7 @@
      org-transclusion-font-lock-extension-functions :remove)))
 
 (defvar org-transclusion-font-lock-extension-functions
-  '((cons 'org-font-lock-set-keywords-hook #'org-transclusion-font-lock-set))
+  (list (cons 'org-font-lock-set-keywords-hook #'org-transclusion-font-lock-set))
   "Alist of functions to activate `org-transclusion-font-lock'.
 CAR of each cons cell is a symbol name of an abnormal hook
 \(*-functions\). CDR is either a symbol or list of symbols, which

--- a/org-transclusion-html.el
+++ b/org-transclusion-html.el
@@ -52,7 +52,7 @@
      org-transclusion-html-extension-functions :remove)))
 
 (defvar org-transclusion-html-extension-functions
-  '((cons 'org-transclusion-add-functions #'org-transclusion-html-add-file))
+  (list (cons 'org-transclusion-add-functions #'org-transclusion-html-add-file))
   "Alist of functions to activate `org-transclusion-html'.
 CAR of each cons cell is a symbol name of an abnormal hook
 \(*-functions\). CDR is either a symbol or list of symbols, which

--- a/org-transclusion-html.el
+++ b/org-transclusion-html.el
@@ -1,6 +1,6 @@
 ;;; org-transclusion-html.el --- Converting HTML content to Org -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2024  Free Software Foundation, Inc.
+;; Copyright (C) 2024-2025 Free Software Foundation, Inc.
 
 ;; This program is free software; you can redistribute it and/or
 ;; modify it under the terms of the GNU Affero General Public License
@@ -31,6 +31,7 @@
 
 ;;;; Requirements
 
+(require 'org-transclusion)
 (require 'org)
 (require 'org-element)
 (require 'cl-lib)
@@ -39,7 +40,24 @@
 
 ;;;; Hook into org-transclusion
 
-(add-hook 'org-transclusion-add-functions #'org-transclusion-html-add-file)
+;;;###autoload
+(define-minor-mode org-transclusion-html-mode ()
+  :lighter nil
+  :global t
+  :group 'org-transclusion
+  (if org-transclusion-html-mode
+      (org-transclusion-extension-functions-add-or-remove
+       org-transclusion-html-extension-functions)
+    (org-transclusion-extension-functions-add-or-remove
+     org-transclusion-html-extension-functions :remove)))
+
+(defvar org-transclusion-html-extension-functions
+  '((cons 'org-transclusion-add-functions #'org-transclusion-html-add-file))
+  "Alist of functions to activate `org-transclusion-html'.
+CAR of each cons cell is a symbol name of an abnormal hook
+\(*-functions\). CDR is either a symbol or list of symbols, which
+are names of functions to be called in the corresponding abnormal
+hook.")
 
 ;;;; Functions
 

--- a/org-transclusion-indent-mode.el
+++ b/org-transclusion-indent-mode.el
@@ -42,8 +42,8 @@
      org-transclusion-indent-extension-functions :remove)))
 
 (defvar org-transclusion-indent-extension-functions
-  '((cons 'org-transclusion-after-add-functions
-          #'org-translusion-indent-add-properties))
+  (list (cons 'org-transclusion-after-add-functions
+              #'org-translusion-indent-add-properties))
   "Alist of functions to activate `org-transclusion-indent-mode'.
 CAR of each cons cell is a symbol name of an abnormal hook
 \(*-functions\). CDR is either a symbol or list of symbols, which

--- a/org-transclusion-indent-mode.el
+++ b/org-transclusion-indent-mode.el
@@ -1,6 +1,6 @@
 ;;; org-transclusion-indent-mode.el --- support org-indent-mode -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021-2024  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2025  Free Software Foundation, Inc.
 
 ;; This program is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by the
@@ -17,7 +17,7 @@
 
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; Created: 22 August 2021
-;; Last modified: 21 January 2024
+;; Last modified: 02 January 2025
 
 ;;; Commentary:
 ;;  This file is part of Org-transclusion
@@ -25,12 +25,30 @@
 
 ;;; Code:
 
+(require 'org-transclusion)
 (require 'org-indent)
 (declare-function org-transclusion-within-transclusion-p
                   "org-transclusion")
 
-(add-hook 'org-transclusion-after-add-functions
-          #'org-translusion-indent-add-properties)
+;;;###autoload
+(define-minor-mode org-transclusion-indent-mode ()
+  :lighter nil
+  :global t
+  :group 'org-transclusion
+  (if org-transclusion-indent-mode
+      (org-transclusion-extension-functions-add-or-remove
+       org-transclusion-indent-extension-functions)
+    (org-transclusion-extension-functions-add-or-remove
+     org-transclusion-indent-extension-functions :remove)))
+
+(defvar org-transclusion-indent-extension-functions
+  '((cons 'org-transclusion-after-add-functions
+          #'org-translusion-indent-add-properties))
+  "Alist of functions to activate `org-transclusion-indent-mode'.
+CAR of each cons cell is a symbol name of an abnormal hook
+\(*-functions\). CDR is either a symbol or list of symbols, which
+are names of functions to be called in the corresponding abnormal
+hook.")
 
 (defun org-translusion-indent-add-properties (beg end)
   "BEG END."

--- a/org-transclusion-src-lines.el
+++ b/org-transclusion-src-lines.el
@@ -1,6 +1,6 @@
 ;;; org-transclusion-src-lines.el --- Extension -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2021-2024  Free Software Foundation, Inc.
+;; Copyright (C) 2021-2025  Free Software Foundation, Inc.
 
 ;; This program is free software: you can redistribute it and/or modify it
 ;; under the terms of the GNU General Public License as published by the
@@ -17,7 +17,7 @@
 
 ;; Author: Noboru Ota <me@nobiot.com>
 ;; Created: 24 May 2021
-;; Last modified: 27 December 2024
+;; Last modified: 02 January 2025
 
 ;;; Commentary:
 ;;  This is an extension to `org-transclusion'.  When active, it adds features
@@ -25,6 +25,7 @@
 
 ;;; Code:
 
+(require 'org-transclusion)
 (require 'org-element)
 (declare-function text-clone-make-overlay "text-clone")
 (declare-function org-transclusion-live-sync-buffers-others-default
@@ -34,34 +35,45 @@
 
 ;;;; Setting up the extension
 
-;; Add a new transclusion type
-(add-hook 'org-transclusion-add-functions
-          #'org-transclusion-add-src-lines)
-;; Keyword values
-(add-hook 'org-transclusion-keyword-value-functions
-          #'org-transclusion-keyword-value-lines)
-(add-hook 'org-transclusion-keyword-value-functions
-          #'org-transclusion-keyword-value-src)
-(add-hook 'org-transclusion-keyword-value-functions
-          #'org-transclusion-keyword-value-rest)
-(add-hook 'org-transclusion-keyword-value-functions
-          #'org-transclusion-keyword-value-end)
-(add-hook 'org-transclusion-keyword-value-functions
-          #'org-transclusion-keyword-value-thing-at-point)
-;; plist back to string
-(add-hook 'org-transclusion-keyword-plist-to-string-functions
-          #'org-transclusion-keyword-plist-to-string-src-lines)
+;;;###autoload
+(define-minor-mode org-transclusion-src-lines-mode ()
+  :lighter nil
+  :global t
+  :group 'org-transclusion
+  (if org-transclusion-src-lines-mode
+      (org-transclusion-extension-functions-add-or-remove
+       org-transclusion-src-lines-extension-functions)
+    (org-transclusion-extension-functions-add-or-remove
+     org-transclusion-src-lines-extension-functions :remove)))
 
-;; Transclusion content formatting
-(add-hook 'org-transclusion-content-format-functions
-          #'org-transclusion-content-format-src-lines)
-
-;; Open source buffer
-(add-hook 'org-transclusion-open-source-marker-functions
-          #'org-transclusion-open-source-marker-src-lines)
-;; Live-sync
-(add-hook 'org-transclusion-live-sync-buffers-functions
-          #'org-transclusion-live-sync-buffers-src-lines)
+(defvar org-transclusion-src-lines-extension-functions
+  (list
+   ;; Add a new transclusion type
+   (cons 'org-transclusion-add-functions #'org-transclusion-add-src-lines)
+    ;; Keyword values
+   (cons 'org-transclusion-keyword-value-functions
+         '(org-transclusion-keyword-value-lines
+           org-transclusion-keyword-value-src
+           org-transclusion-keyword-value-rest
+           org-transclusion-keyword-value-end
+           org-transclusion-keyword-value-thing-at-point))
+   ;; plist back to string
+   (cons 'org-transclusion-keyword-plist-to-string-functions
+         #'org-transclusion-keyword-plist-to-string-src-lines)
+   ;; Transclusion content formatting
+   (cons 'org-transclusion-content-format-functions
+         #'org-transclusion-content-format-src-lines)
+   ;; Open source buffer
+   (cons 'org-transclusion-open-source-marker-functions
+         #'org-transclusion-open-source-marker-src-lines)
+   ;; Live-sync
+   (cons 'org-transclusion-live-sync-buffers-functions
+         #'org-transclusion-live-sync-buffers-src-lines))
+  "Alist of functions to activate `org-transclusion-src-lines'.
+CAR of each cons cell is a symbol name of an abnormal hook
+\(*-functions\). CDR is either a symbol or list of symbols, which
+are names of functions to be called in the corresponding abnormal
+hook.")
 
 ;;; Functions
 

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -17,7 +17,7 @@
 
 ;; Author:        Noboru Ota <me@nobiot.com>
 ;; Created:       10 October 2020
-;; Last modified: 02 January 2025
+;; Last modified: 03 January 2025
 
 ;; URL: https://github.com/nobiot/org-transclusion
 ;; Keywords: org-mode, transclusion, writing
@@ -942,13 +942,19 @@ hooks in `org-transclusion-add-functions'."
         (run-hook-with-args 'org-transclusion-after-add-functions beg end))
       t)))
 
+(defun org-transclusion-id-marker (path)
+  (save-selected-window
+    (org-id-open path nil)
+    ;; In the target buffer temporarily
+    (move-marker (make-marker) (point))))
+
 (defun org-transclusion-add-org-id (link plist)
   "Return a list for Org-ID LINK object and PLIST.
 Return nil if not found."
   (when (string= "id" (org-element-property :type link))
     ;; when type is id, the value of path is the id
-    (let* ((id (org-element-property :path link))
-           (mkr (ignore-errors (org-id-find id t)))
+    (let* ((path (org-element-property :path link))
+           (mkr (ignore-errors (org-transclusion-id-marker path)))
            (payload '(:tc-type "org-id")))
       (if mkr
           (append payload (org-transclusion-content-org-marker mkr plist))

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -942,9 +942,9 @@ hooks in `org-transclusion-add-functions'."
         (run-hook-with-args 'org-transclusion-after-add-functions beg end))
       t)))
 
-(defun org-transclusion-id-marker (path)
+(defun org-transclusion-id-marker (link)
   (save-selected-window
-    (org-id-open path nil)
+    (org-link-open link)
     ;; In the target buffer temporarily
     (move-marker (make-marker) (point))))
 
@@ -953,8 +953,7 @@ hooks in `org-transclusion-add-functions'."
 Return nil if not found."
   (when (string= "id" (org-element-property :type link))
     ;; when type is id, the value of path is the id
-    (let* ((path (org-element-property :path link))
-           (mkr (ignore-errors (org-transclusion-id-marker path)))
+    (let* ((mkr (ignore-errors (org-transclusion-id-marker link)))
            (payload '(:tc-type "org-id")))
       (if mkr
           (append payload (org-transclusion-content-org-marker mkr plist))

--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -42,7 +42,6 @@
 (require 'text-clone)
 (require 'text-property-search)
 (require 'seq)
-(require 'cl-macs) ; for cl-loop
 
 ;;;; Customization
 
@@ -1835,7 +1834,7 @@ ensure the settings revert to the user's setting prior to
   "Promote or demote transcluded subtree.
 When DEMOTE is non-nil, demote."
   (unless (org-transclusion-within-transclusion-p)
-    (user-error "Not in a transcluded headline."))
+    (user-error "Not in a transcluded headline"))
   (let* ((inhibit-read-only t)
          (beg (car (plist-get (org-transclusion-at-point) :location)))
          (pos (point)))

--- a/test/test-2.0.org
+++ b/test/test-2.0.org
@@ -2,6 +2,11 @@
 ** make from link
 This is a link to a [[id:2022-05-30T203553][Bertrand Russell]] wikipedia excerpt
 #+transclude: [[id:2022-05-30T203553][Bertrand Russell]]
+
+#+transclude: [[id:2022-10-10T173507::*H2]]
+
+[[id:2022-10-10T173507::*H2]]
+
 ** test empty file
 #+transclude: [[file:empty.txt::2][empty text file]]
 
@@ -199,4 +204,3 @@ Temporarily set ~org-transclusion-include-first-section~ to nil
   # id-1234 end here
   return fname # return this to org-mode
 #+end_src
-

--- a/test/test-2.0.org
+++ b/test/test-2.0.org
@@ -1,11 +1,37 @@
 * Regression
-** make from link
+** notmuch
+
+   #+transclude: [[notmuch:id:E5208A8C-F56A-4931-9E9F-A1F5F78B8698@nobiot.com]]
+
+   [[notmuch:id:E5208A8C-F56A-4931-9E9F-A1F5F78B8698@nobiot.com]]
+** search option
+
+#+transclude: [[file:paragraph.org]]
+=> transclude entire buffer
+
+#+transclude: [[file:paragraph.org::Sub heading]]
+=> Sub heading only
+
+#+transclude: [[file:paragraph.org::non-exisitent]]
+=> Should not transclude anything
+
+** make from link -- id
 This is a link to a [[id:2022-05-30T203553][Bertrand Russell]] wikipedia excerpt
 #+transclude: [[id:2022-05-30T203553][Bertrand Russell]]
 
 #+transclude: [[id:2022-10-10T173507::*H2]]
 
 [[id:2022-10-10T173507::*H2]]
+
+ID with "first section" [[id:2022-06-26T152831]]
+
+#+begin_src emacs-lisp
+  (setq org-transclusion-include-first-section nil)
+  (setq org-transclusion-include-first-section t)
+#+end_src
+
+#+transclude: [[id:2022-06-26T152831]]
+
 
 ** test empty file
 #+transclude: [[file:empty.txt::2][empty text file]]


### PR DESCRIPTION
[fix(add): org-id with search option (::*heading)](https://github.com/nobiot/org-transclusion/commit/c910289f97441ce9a4751ece2d47ce0038b3bb90) https://github.com/nobiot/org-transclusion/issues/237
[c910289](https://github.com/nobiot/org-transclusion/commit/c910289f97441ce9a4751ece2d47ce0038b3bb90)

While fixing the issue, I am extending the "add" operation to allow for *any*
link.  A lot is still under development and many things will change. But this
seems to work without breaking any user-facing commands and function.

Introduced a new function `org-transclusion-add-target-marker`, which helps
transcluding *any* link (as long as Org can reach the link target and Emacs
creates the link's target buffer -- tested with `notmuch` link successfully).

Refactored the code for the "add" operation with this new approach.