### PR TITLE
Add :level auto and :no-first-heading

### DIFF
--- a/test/test-2.0.org
+++ b/test/test-2.0.org
@@ -199,4 +199,22 @@ Temporarily set ~org-transclusion-include-first-section~ to nil
   # id-1234 end here
   return fname # return this to org-mode
 #+end_src
+* Test "auto" level
 
+  #+transclude: [[file:bertrand-russell.org::*On Denoting]] :level
+
+*** A auto level
+
+  #+transclude: [[file:bertrand-russell.org::*On Denoting]] :level  :exclude-elements "headline drawer"
+
+
+  #+transclude: [[file:bertrand-russell.org::*On Denoting]] :level 3 :exclude-elements "headline drawer"
+
+*** First sectiona and "auto" level
+
+#+begin_src emacs-lisp
+  (setq org-transclusion-include-first-section nil)
+  (setq org-transclusion-include-first-section t)
+#+end_src
+
+  #+transclude: [[file:./test-no-first-section.org]] :level


### PR DESCRIPTION
https://github.com/nobiot/org-transclusion/issues/195
https://github.com/nobiot/org-transclusion/issues/254
https://github.com/nobiot/org-transclusion/pull/268

Rebased on current `main` (2025-12-19).

Not tested yet.

I have FSF assignment.

### Note on org-reduced-level

One effect on existing behavior is [around line 2040](https://github.com/nobiot/org-transclusion/pull/282/commits/5631b3c466751453beb7b960e106547da8e75345#diff-29f1cd55e345a56cf587cf1a3ed5e8af31e9be6a9898fdb629acfe188a72ffceL2035-R2043) ~~where I opted to change `(car (org-heading-components))` for `(org-reduced-level (org-current-level))`, even for the case where `:level` is a number and not "auto".~~

EDIT: Separated out that fix as an optional third commit.  It is not necessary for this PR.