### PR TITLE
refactor: consolidate fringe management functions

### DIFF
--- a/org-transclusion-indent-mode.el
+++ b/org-transclusion-indent-mode.el
@@ -55,9 +55,9 @@ Either nil, t (initialized), or (TIMER ATTEMPT-COUNT).")
 ;;;; Forward Declarations
 
 ;; Silence byte-compiler warnings for functions defined in org-transclusion.el
-(declare-function org-transclusion-prefix-has-fringe-p "org-transclusion" (prefix))
-(declare-function org-transclusion-add-fringe-to-region "org-transclusion" (buffer beg end face))
-(declare-function org-transclusion-remove-fringe-from-region "org-transclusion" (buffer beg end))
+(declare-function org-transclusion--prefix-has-fringe-p "org-transclusion" (prefix))
+(declare-function org-transclusion-add-fringes "org-transclusion" (buffer beg end face))
+(declare-function org-transclusion-remove-fringes "org-transclusion" (buffer beg end))
 
 
 ;; Variable defined by define-minor-mode later in this file
@@ -100,12 +100,12 @@ org-indent may regenerate individual lines during typing."
                     (let* ((line-beg (line-beginning-position))
                            (line-prefix (get-text-property line-beg 'line-prefix)))
                       (when (and line-prefix
-                                 (not (org-transclusion-prefix-has-fringe-p line-prefix)))
-                        (org-transclusion-add-fringe-to-region
+                                 (not (org-transclusion--prefix-has-fringe-p line-prefix)))
+                        (org-transclusion-add-fringes
                          (current-buffer) ov-beg ov-end
                          'org-transclusion-source-fringe))))
                 ;; Terminal mode: always re-apply to all lines
-                (org-transclusion-add-fringe-to-region
+                (org-transclusion-add-fringes
                  (current-buffer) ov-beg ov-end
                  'org-transclusion-source-fringe)))))))))
 
@@ -208,7 +208,7 @@ by appending them to org-indent's indentation prefixes."
                   (actual-end (prop-match-end match)))
         ;; Apply org-indent properties and fringes to actual bounds
         (org-indent-add-properties actual-beg actual-end)
-        (org-transclusion-add-fringe-to-region
+        (org-transclusion-add-fringes
          (current-buffer) actual-beg actual-end 'org-transclusion-fringe)))))
 
 (defun org-transclusion-indent--refresh-source-region (src-buf src-beg src-end)
@@ -227,7 +227,7 @@ transclusion."
                      org-transclusion-indent-mode)
             (org-transclusion-indent--check-and-disable)))
       ;; Non-org buffer or org buffer without indent-mode: just remove fringes
-      (org-transclusion-remove-fringe-from-region src-buf src-beg src-end))))
+      (org-transclusion-remove-fringes src-buf src-beg src-end))))
 
 ;;;; Minor Mode Definition
 


### PR DESCRIPTION
Fringe management functions consolidated into:

```elisp
;;;;; Core Operations
(defun org-transclusion--make-fringe-string (face))
(defun org-transclusion--prefix-has-fringe-p (prefix))

;;;;; Region Operations
(defun org-transclusion-add-fringes (buffer beg end face))
(defun org-transclusion-remove-fringes (buffer beg end))
```

With this I&rsquo;ve also adapted all places where the previous fringe placemente functions where being called in org-transclusion.el and org-transclusion-indent-mode.el

such as

org-transclusion-indent-mode.el

```diff
-(declare-function org-transclusion-prefix-has-fringe-p "org-transclusion" (prefix))
-(declare-function org-transclusion-add-fringe-to-region "org-transclusion" (buffer beg end face))
-(declare-function org-transclusion-remove-fringe-from-region "org-transclusion" (buffer beg end))
+(declare-function org-transclusion--prefix-has-fringe-p "org-transclusion" (prefix))
+(declare-function org-transclusion-add-fringes "org-transclusion" (buffer beg end face))
+(declare-function org-transclusion-remove-fringes "org-transclusion" (buffer beg end))
```

```diff
-                                 (not (org-transclusion-prefix-has-fringe-p line-prefix)))
-                        (org-transclusion-add-fringe-to-region
+                                 (not (org-transclusion--prefix-has-fringe-p line-prefix)))
+                        (org-transclusion-add-fringes
```

```diff
-                (org-transclusion-add-fringe-to-region
+                (org-transclusion-add-fringes
```

```diff
-      (org-transclusion-remove-fringe-from-region src-buf src-beg src-end))))
+      (org-transclusion-remove-fringes src-buf src-beg src-end))))
```

Same deal on `org-transclusion.el`

Besides refactoring the fringe functions, I&rsquo;ve also added an hybrid approach that applies fringes through different mechanisms depending on org-indent-mode being enabled or not.

This was due to the following problem: If indent-mode and the transclusion-indent-mode extension are disabled, the per-line text property approach is unable to preserve fringes in the source when executing `revert-buffer`. The original implementation before the indent-mode additions did not have this issue because it placed the fringes as overlay properties, which survived buffer-revert and other changes to the buffer..

So, since fringe placement through overlays is only an issue if we want to preserve indentation, I&rsquo;ve made it so fringes will be placed through overlays WHEN org-indent-mode is disabled. If not, then we&rsquo;ll default to the per line text property approach.

> [!NOTE] If the extension org-transclusion-indent-mode is not enabled but org-indent-mode **is**, indentation will be preserved, but fringes will still be lost to revert-buffer and other font locking operations on the transclusion source buffer, so the extension is still necessary if we want fringes to work properly with indent-mode.

Another detail is that when `org-indent-mode` is active without the transclusion-indent-mode extension loaded, fringes can still be reapplied during normal buffer modifications via the overlay modification hook, but NOT after `revert-buffer` (which doesn't trigger modification hooks when content is unchanged). Users who need full `org-indent-mode` support including buffer reverts should load the `org-transclusion-indent-mode` extension.

SUMMARY:

| Retaining fringes - Scenarios  | Normal Editing  | revert-buffer, font-lock/etc | Description                                                                                                                    |
|------------------------------ |--------------- |---------------------------- |------------------------------------------------------------------------------------------------------------------------------ |
| indent-mode OFF                | YES (overlay)   | YES (overlay)                | Works as intented, overlay ensures fringe is retained and adapts to changes in buffer                                          |
| indent-mode ON, no extension   | YES (hook)      | NO                           | Fringe will survive manual buffer modification, but will be lost on font-lock and other buffer operations such as rever-buffer |
| indent-mode ON, with extension | YES (extension) | YES (extension)              | Fringe will be reapplied in case of text-property erasure, works without issues.                                               |
