### PR TITLE
fix: enforce point-min when :lines transclusion has no search string

### DIFF
--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -1081,7 +1081,11 @@ returned by hooks in `org-transclusion-add-functions'."
   "Return the marker of transclusion source by opening LINK.
 LINK must be Org's link object that `org-link-open' can act on. As long
 as `org-link-open' opens a buffer within Emacs, this function should
-return a marker."
+return a marker.
+
+When LINK has no search option (::*Heading, ::CUSTOM_ID, etc.), returns
+marker at `point-min' to ensure line-based transclusions calculate
+offsets from file beginning, not from cursor position."
   ;; Assume the point now is the transcluding buffer
   ;; Note 2025-12-18 `org-link-open' does not necessarily obey
   ;; `display-buffer-alist' and can open the target buffer in the currently
@@ -1100,6 +1104,11 @@ return a marker."
               (org-link-open link)
               ;; In the target buffer temporarily.
               (save-excursion
+                ;; When link has no search option, go to
+                ;; point-min so :lines offsets calculate from file start,
+                ;; not from wherever cursor happened to be in source buffer.
+                (when (not (org-element-property :search-option link))
+                  (goto-char (point-min)))
                 (move-marker (make-marker) (point))))
           (error (user-error
                   "Org-transclusion: `org-link-open' cannot open link, %s"


### PR DESCRIPTION
Fixes #286 

-   actions:
    1.  create transclusion for line range
    2.  open the transclusion source buffer and move to a different line
    3.  refresh transclusion

when doing a transclusion, its results changed after moving around the source buffer:

Position of the cursor when doing the transclusion: 
    `#+transclude: [[file:~/CODE/0-EMACS/emacs-packages/org-transclusion/org-transclusion.el]] :lines 100-105 :src elisp`

-   moving to line 200, transcluded region starts at line 299
-   moving to line 300: transcluded region starts at 399
-   moving to line 1000: transcluded region starts at 1099

So obviously there&rsquo;s an offset of X lines relative to the cursor position in the source buffer, it's using the first number in :lines as 0 and them moving down a line x times, explaining the 99 since our lines param was 100.

<a id="org101da37"></a>

# Root Cause

It&rsquo;s due to save-excursion saving the point AND current buffer.

```c
DEFUN ("save-excursion", Fsave_excursion, Ssave_excursion, 0, UNEVALLED, 0,
       doc: /* Save point, and current buffer; execute BODY; restore those things.
Executes BODY just like `progn'.
The values of point and the current buffer are restored
even in case of abnormal exit (throw or error).

If you only want to save the current buffer but not point,
then just use `save-current-buffer', or even `with-current-buffer'.
...
```

The only actual issue with this is that if there&rsquo;s no search string, it uses the last place you placed the cursor on the source buffer.

Forcing point-min when there's no :search string fixes it.

```elisp
(progn
  (org-link-open link)
  ;; In the target buffer temporarily.
  (save-excursion
    ;; When link has no search option, go to
    ;; point-min so :lines offsets calculate from file start,
    ;; not from wherever cursor happened to be in source buffer.
    (when (not (org-element-property :search-option link))
      (goto-char (point-min)))
    (move-marker (make-marker) (point))))
```

I&rsquo;ve tested this on the same examples shown above and seems to fix the issue, while retaining the functionality of transcluding lines relative to search string result.
