### PR TITLE
fix: #203 Wrong indentation some transcluded python src block

### DIFF
--- a/org-transclusion.el
+++ b/org-transclusion.el
@@ -17,7 +17,7 @@
 
 ;; Author:        Noboru Ota <me@nobiot.com>
 ;; Created:       10 October 2020
-;; Last modified: 04 January 2026
+;; Last modified: 15 January 2026
 
 ;; URL: https://github.com/nobiot/org-transclusion
 ;; Keywords: org-mode, transclusion, writing
@@ -135,6 +135,17 @@ It is expected that these functions prompt for user to choose / create a
 link, but as long as the function insert a valid org link in a buffer,
 it will work. Used in `org-transclusion-insert-org-link', which see."
   :type '(repeat function))
+
+(defcustom org-transclusion-src-tab-acts-natively t
+  "Flag to control how transclusion deals with tabs for org-src.
+The default is t. When it is t, use `org-src-tab-acts-natively' as is.
+If set to nil, Org-transclusion temporarily sets
+`org-src-tab-acts-natively' to nil when transcluded content is being
+formated.
+
+Change it to nil if indentention is not transcluded correctly from the
+program source, especially for the languages where indentation is
+significant such as Python and YAML.")
 
 ;;;; Faces
 
@@ -539,8 +550,11 @@ does not support all the elements.
                 (point) (org-current-line))))
             ;; Normal case
             (t
-             (pcase-let ((buffer-modified-p (buffer-modified-p))
-                         (`(,beg . ,end) (org-transclusion-content-insert content)))
+             (pcase-let* ((org-src-tab-acts-natively (if (not org-transclusion-src-tab-acts-natively)
+                                                         nil
+                                                       org-src-tab-acts-natively))
+                          (buffer-modified-p (buffer-modified-p))
+                          (`(,beg . ,end) (org-transclusion-content-insert content)))
                (when (and beg end)
                  ;; If COPY, then we want to get the buffer-modified-p flag always t.
                  ;; If transclusion, it should be the same as before transclusion.


### PR DESCRIPTION
Added a new user option namded `org-transclusion-src-tab-acts-natively`. The default is t corresponding to the default value for Org's built-in `org-src-tab-acts-natively`. The behaviour is intended to respect what users set in the built-in `org-src-tab-acts-natively`. It works like this:

The default is t. When it is t, use `org-src-tab-acts-natively' as is. If set to nil, Org-transclusion temporarily sets `org-src-tab-acts-natively' to nil when transcluded content is being formated.